### PR TITLE
完全なentries.txtの生成とデータ取得先の負担軽減とお知らせの件数表示

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,6 @@ lerna-debug.log*
 # misc
 .DS_Store
 
-wrangler.toml
-
 bun.lockb
 
 _headers

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,4 @@ lerna-debug.log*
 
 bun.lockb
 
-_headers
-
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ wrangler login
 
 ### 4. wrangler.example.toml を wrangler.toml にする。
 
+既存の wrangler.toml がある場合は、削除してください。
+
+
 ### 5. ターミナルで Cloudflare KV の名前空間を作成する。
 
 ```bash

--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -13,6 +13,7 @@ const KemonoFriends3NewsSearch = () => {
   const [isSearchVisible, setIsSearchVisible] = useState(false); // 検索欄の表示状態
   const [startDate, setStartDate] = useState("2019-09-24"); // フィルター開始日
   const [endDate, setEndDate] = useState(new Date().toISOString().split("T")[0]); // フィルター終了日
+  const [numberOfNews, setNumberOfNews] = useState(0); // ニュースの数
 
   // コンポーネント初回レンダリング時にニュースデータを取得
   useEffect(() => {
@@ -29,6 +30,7 @@ const KemonoFriends3NewsSearch = () => {
           const sortedData = getSortedNews(result.data); // 全データをソート
           setAllNewsData(sortedData); // 全データをセット
           setNewsData(sortedData.slice(0, displayLimit)); // 初期表示データをセット
+          setNumberOfNews(sortedData.length); // ニュースの件数を設定
         } else {
           console.error("Data validation failed", result.error);
         }
@@ -62,6 +64,7 @@ const KemonoFriends3NewsSearch = () => {
     filteredNews = filterNewsByKeyword(allNewsData, searchKeyword);
     filteredNews = filterNewsByDate(filteredNews, startDate, endDate);
     const sortedNews = getSortedNews(filteredNews);
+    setNumberOfNews(filteredNews.length);
     setNewsData(sortedNews.slice(0, displayLimit));
   };
 
@@ -289,6 +292,10 @@ const KemonoFriends3NewsSearch = () => {
           </div>
         </div>
       )}
+
+      <div class="p-2 m-2">
+        <span>おしらせの件数: {numberOfNews}件</span>
+      </div>
 
       <ul>
         {newsData.map((news, index) => (

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,3 @@
+https://kf3-notification-search.pages.dev/*
+https://kf3-notification-search-preview.pages.dev/*
+X-Robots-Tag: noindex

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,4 @@ export default defineConfig({
     }),
     build(),
   ],
-  ssr: {
-    external: ["node:async_hooks"],
-  },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,4 +13,7 @@ export default defineConfig({
     }),
     build(),
   ],
+  ssr: {
+    external: ["node:async_hooks"],
+  },
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,8 @@
+name = "kf3-notification-search"
+compatibility_date = "2024-04-01"
+compatibility_flags = [ "nodejs_compat" ]
+pages_build_output_dir = "./dist"
+
+[[kv_namespaces]]
+binding = "KF3_API_CACHE"
+id = "d8e8bad87034484abc3f5c9c806d0122"


### PR DESCRIPTION
## 概要

- 完全なentries.txtの生成とデータ取得先の負担軽減をします。
- おしらせの件数を表示する機能を追加します。

## 実装した背景

- infoカテゴリーのentries.txtも2000件を超えているため漏れがある
- 以下に該当するお知らせは7つのentries.txtのどれにも含まれていない
  - 「スペシャル」カテゴリーしかついていないお知らせ
  - 「お知らせ」カテゴリーのついていないお知らせ
- おしらせ件数を表示したい

## 詳細

- @reamkf さんに用意していただいた2024/11/07以前のお知らせ(entries_merged_20241107.json)と公式サイトの最新2000件までのお知らせ（https\://kemono-friends-3.jp/info/all/entries.txt）をマージして配信します。
- 公式サイトから7件取得していたものを1件に抑えます。
- 検索する関数である`handleSearch()`を実行した際に、`setNumberOfNews()`を実行し検索されたおしらせの件数を表示します。（※表示された件数ではなく、検索にヒットした件数です。）

## 確認方法

- https\://kemono-friends-3.jp/info/all/entries.txt では合計4013件のおしらせがあるので、今回実装したおしらせ件数の表示機能を利用して4013件以上のおしらせがあることを確認すること。
- スペシャルカテゴリーのおしらせである「神戸どうぶつ王国×けものフレンズ3のコラボ決定！」を検索して表示されるのを確認すること。
- 表示された件数ではなく、検索にヒットした件数が表示されていることを確認すること。

## 関連する Issue

- close #2 