### PR TITLE
各おしらせに min-height を設定する

### DIFF
--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -319,7 +319,7 @@ const KemonoFriends3NewsSearch = () => {
                   target="_blank"
                   class="flex flex-col justify-between"
                 >
-                  <p class="h-16 overflow-hidden text-base">{news.title}</p>
+                  <p class="min-h-16 overflow-hidden text-base">{news.title}</p>
                   <span class="text-xs mt-auto">{news.newsDate.slice(0, 11)}</span>
                 </a>
               </li>


### PR DESCRIPTION
## 概要
おしらせが3行以上あると見切れてしまう問題があったので、固定の height から min-height に修正する。

## 確認方法
- 開発者コンソールでSP表示に変更し、「(11/14 14:30更新)寒中水泳ログインストーリー公開＆「水着」シリーズの着せ替え対象追加と一部復刻を開催！」が見切れていないか確認すること。
- レスポンシブ表示にして、画面が崩れないことを確認すること。