### PR TITLE
表示件数周りの修正と改善

### DIFF
--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -33,6 +33,17 @@ const KemonoFriends3NewsSearch = () => {
           setAllNewsData(sortedData); // 全データをセット
           setNewsData(sortedData.slice(0, selectedDisplayLimit)); // 初期表示データをセット
           setNumberOfNews(sortedData.length); // ニュースの件数を設定
+
+          // 表示件数を設定
+          const savedDisplayLimit = localStorage.getItem("selectedDisplayLimit");
+          if (savedDisplayLimit) {
+            const limit =
+              savedDisplayLimit === "all"
+                  ? sortedData.length
+                  : Number(savedDisplayLimit);
+            setSelectedDisplayLimit(limit);
+            setDisplayLimit(limit);
+          }
         } else {
           console.error("Data validation failed", result.error);
         }
@@ -124,6 +135,7 @@ const KemonoFriends3NewsSearch = () => {
           : Number(event.target.value);
       setSelectedDisplayLimit(newLimit);
       setDisplayLimit(newLimit);
+      localStorage.setItem("selectedDisplayLimit", event.target.value);
     }
   };
 

--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -7,6 +7,7 @@ const KemonoFriends3NewsSearch = () => {
   const [newsData, setNewsData] = useState<Array<News>>([]); // 表示されるニュースデータ
   const [allNewsData, setAllNewsData] = useState<Array<News>>([]); // 全ニュースデータ
   const [searchKeyword, setSearchKeyword] = useState(""); // 検索キーワード
+  const [selectedDisplayLimit, setSelectedDisplayLimit] = useState(10); // 選択された表示件数
   const [displayLimit, setDisplayLimit] = useState(10); // 表示件数
   const [sortOrder, setSortOrder] = useState("desc"); // ソート順
   const [sortField, setSortField] = useState("newsDate"); // ソート基準
@@ -30,7 +31,7 @@ const KemonoFriends3NewsSearch = () => {
         if (result.success) {
           const sortedData = getSortedNews(result.data); // 全データをソート
           setAllNewsData(sortedData); // 全データをセット
-          setNewsData(sortedData.slice(0, displayLimit)); // 初期表示データをセット
+          setNewsData(sortedData.slice(0, selectedDisplayLimit)); // 初期表示データをセット
           setNumberOfNews(sortedData.length); // ニュースの件数を設定
         } else {
           console.error("Data validation failed", result.error);
@@ -47,7 +48,7 @@ const KemonoFriends3NewsSearch = () => {
   // 検索キーワードを除く検索条件が変更されたときに検索を実行
   useEffect(() => {
     handleSearch();
-  }, [displayLimit, sortOrder, sortField, startDate, endDate]);
+  }, [selectedDisplayLimit, displayLimit, sortOrder, sortField, startDate, endDate]);
 
   // 検索キーワードの変更をハンドリング
   const handleSearchChange = (event: Event) => {
@@ -115,12 +116,13 @@ const KemonoFriends3NewsSearch = () => {
   };
 
   // 表示件数を変更する
-  const handleDisplayLimitChange = (event: Event) => {
+  const handleSelectedDisplayLimitChange = (event: Event) => {
     if (event.target instanceof HTMLInputElement) {
       const newLimit =
         event.target.value === "all"
           ? allNewsData.length
           : Number(event.target.value);
+      setSelectedDisplayLimit(newLimit);
       setDisplayLimit(newLimit);
     }
   };
@@ -230,8 +232,8 @@ const KemonoFriends3NewsSearch = () => {
                   id="limit10"
                   name="displayLimit"
                   value="10"
-                  checked={displayLimit === 10}
-                  onChange={handleDisplayLimitChange}
+                  checked={selectedDisplayLimit === 10}
+                  onChange={handleSelectedDisplayLimitChange}
                 />
                 <label for="limit10">10件</label>
                 <input
@@ -239,8 +241,8 @@ const KemonoFriends3NewsSearch = () => {
                   id="limit50"
                   name="displayLimit"
                   value="50"
-                  checked={displayLimit === 50}
-                  onChange={handleDisplayLimitChange}
+                  checked={selectedDisplayLimit === 50}
+                  onChange={handleSelectedDisplayLimitChange}
                 />
                 <label for="limit50">50件</label>
                 <input
@@ -248,8 +250,8 @@ const KemonoFriends3NewsSearch = () => {
                   id="limit100"
                   name="displayLimit"
                   value="100"
-                  checked={displayLimit === 100}
-                  onChange={handleDisplayLimitChange}
+                  checked={selectedDisplayLimit === 100}
+                  onChange={handleSelectedDisplayLimitChange}
                 />
                 <label for="limit100">100件</label>
                 <input
@@ -257,8 +259,8 @@ const KemonoFriends3NewsSearch = () => {
                   id="limitAll"
                   name="displayLimit"
                   value="all"
-                  checked={displayLimit === allNewsData.length}
-                  onChange={handleDisplayLimitChange}
+                  checked={selectedDisplayLimit === allNewsData.length}
+                  onChange={handleSelectedDisplayLimitChange}
                 />
                 <label for="limitAll">全件</label>
               </div>

--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -326,15 +326,14 @@ const KemonoFriends3NewsSearch = () => {
             ))}
           </ul>
 
-          {allNewsData.filter((news) => news.title.includes(searchKeyword)).length >
-            displayLimit && (
+          {numberOfNews > displayLimit && (
             <button
               class="p-2 m-2 border border-gray-600 rounded-md bg-blue-500 text-white"
               onClick={handleLoadMore}
             >
               もっと見る
             </button>
-          )}
+          ) || null}
         </>
       )}
     </div>


### PR DESCRIPTION
## 概要
- ヒット件数が表示件数より多いにもかかわらず、「もっと見る」ボタンが表示されない場合がある問題を修正
- 「もっと見る」ボタン押下後、表示件数の選択が外れる問題を修正
- 表示件数の選択状態を、ページ再読み込み後も保持するように変更

## 実装詳細
- ヒット件数が表示件数より多いにもかかわらず、「もっと見る」ボタンが表示されない場合がある問題を修正
  - →ボタンの表示条件文内で`new.title.includes(keyword)`を使った単純なフィルタを行っていたのを、`numberOfNews`変数を使用するように変更
- 「もっと見る」ボタン押下後、表示件数の選択が外れる問題を修正
  - →`displayLimit`変数(もっと見るボタンを押すと加算される)の他に、選択された表示件数を保持する`selectedDisplayLimit`変数を追加
- 表示件数の選択状態を、ページ再読み込み時に保持するように変更
  - →`localStorage`を使用して、`input`の`value`を保持し、サイト初期化時に読み込むように変更

## 確認項目
- 表示件数10件の設定で、「立ち入り禁止　-予告」でキーワードフィルターし、表示件数が16になった状態で、「もっと見る」ボタンが正常に表示されることを確認
- 「もっと見る」ボタンを押下後、表示件数の選択が外れないことを確認
- 表示件数を変更し、ページを再読み込みした後、表示件数の選択状態が保持されていることを確認