### PR TITLE
UI/UXの改善

### DIFF
--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -193,13 +193,12 @@ const KemonoFriends3NewsSearch = () => {
   return (
     <div class="min-h-screen bg-yellow-400 px-4">
       <div class="max-w-6xl mx-auto bg-white shadow-lg rounded-lg p-6 my-4">
-        {isLoading ? (
-          <div class="flex justify-center items-center p-8">
+          <div class={`flex justify-center items-center p-8 ${isLoading ? "" : "hidden"}`}>
             <div class="w-8 h-8 border-4 border-blue-200 border-t-blue-500 rounded-full animate-spin"></div>
             <span class="ml-4 text-gray-600 font-medium">データを取得しています...</span>
           </div>
-        ) : (
-          <div class="space-y-3" >
+
+          <div class={`space-y-3 ${isLoading ? "hidden" : ""}`} >
             {/* 検索欄トグルボタン */}
             <button
               onClick={toggleSearchVisibility}
@@ -355,7 +354,6 @@ const KemonoFriends3NewsSearch = () => {
               </div>
             )}
           </div>
-        )}
       </div>
     </div>
   );

--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -202,7 +202,9 @@ const KemonoFriends3NewsSearch = () => {
             {/* 検索欄トグルボタン */}
             <button
               onClick={toggleSearchVisibility}
-              class="w-full md:w-auto px-6 py-3 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg transition-colors duration-200 flex items-center justify-center gap-2"
+              class={`w-full md:w-auto px-6 py-3 text-white font-medium rounded-lg transition-colors duration-200 flex items-center justify-center gap-2 ${
+                isSearchVisible ? "bg-gray-500 hover:bg-gray-600" : "bg-blue-500 hover:bg-blue-600"
+              }`}
             >
               <svg
                 class={`w-5 h-5 transition-transform duration-200 ${

--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -10,7 +10,6 @@ const KemonoFriends3NewsSearch = () => {
   const [selectedDisplayLimit, setSelectedDisplayLimit] = useState(10); // 選択された表示件数
   const [displayLimit, setDisplayLimit] = useState(10); // 表示件数
   const [sortOrder, setSortOrder] = useState("desc"); // ソート順
-  const [sortField, setSortField] = useState("newsDate"); // ソート基準
   const [isSearchVisible, setIsSearchVisible] = useState(false); // 検索欄の表示状態
   const [startDate, setStartDate] = useState("2019-09-24"); // フィルター開始日
   const [endDate, setEndDate] = useState(new Date().toISOString().split("T")[0]); // フィルター終了日
@@ -59,7 +58,7 @@ const KemonoFriends3NewsSearch = () => {
   // 検索キーワードを除く検索条件が変更されたときに検索を実行
   useEffect(() => {
     handleSearch();
-  }, [selectedDisplayLimit, displayLimit, sortOrder, sortField, startDate, endDate]);
+  }, [selectedDisplayLimit, displayLimit, sortOrder, startDate, endDate]);
 
   // 検索キーワードの変更をハンドリング
   const handleSearchChange = (event: Event) => {
@@ -119,13 +118,6 @@ const KemonoFriends3NewsSearch = () => {
     }
   };
 
-  // ソート基準を変更する
-  const handleSortFieldChange = (event: Event) => {
-    if (event.target instanceof HTMLSelectElement) {
-      setSortField(event.target.value);
-    }
-  };
-
   // 表示件数を変更する
   const handleSelectedDisplayLimitChange = (event: Event) => {
     if (event.target instanceof HTMLInputElement) {
@@ -168,14 +160,8 @@ const KemonoFriends3NewsSearch = () => {
   // ニュースデータをソート
   const getSortedNews = (data: Array<News>) => {
     return data.sort((a, b) => {
-      const aDate =
-        sortField === "updated"
-          ? new Date(a.updated).getTime()
-          : parseDateString(a.newsDate);
-      const bDate =
-        sortField === "updated"
-          ? new Date(b.updated).getTime()
-          : parseDateString(b.newsDate);
+      const aDate = parseDateString(a.newsDate);
+      const bDate = parseDateString(b.newsDate);
       return sortOrder === "asc" ? aDate - bDate : bDate - aDate;
     });
   };
@@ -197,159 +183,189 @@ const KemonoFriends3NewsSearch = () => {
   };
 
   return (
-    <div class="flex flex-col bg-white p-4 m-4 rounded-md">
-      {isLoading ? (
-        <div class="flex justify-center items-center p-4">
-          <div class="w-8 h-8 border-4 border-gray-200 border-t-gray-500 rounded-full animate-spin"></div>
-          <span class="ml-3">データを取得しています...</span>
-        </div>
-      ) : (
-        <>
-          <button
-            class={`p-2 m-2 border border-gray-600 rounded-md text-white ${
-              isSearchVisible ? "bg-gray-500" : "bg-blue-500"
-            }`}
-            onClick={toggleSearchVisibility}
-          >
-            検索欄を{isSearchVisible ? "非表示" : "表示"}
-          </button>
+    <div class="min-h-screen bg-yellow-400 px-4">
+      <div class="max-w-6xl mx-auto bg-white shadow-lg rounded-lg p-6 my-4">
+        {isLoading ? (
+          <div class="flex justify-center items-center p-8">
+            <div class="w-8 h-8 border-4 border-blue-200 border-t-blue-500 rounded-full animate-spin"></div>
+            <span class="ml-4 text-gray-600 font-medium">データを取得しています...</span>
+          </div>
+        ) : (
+          <div class="space-y-6">
+            {/* Search Toggle Button */}
+            <button
+              onClick={toggleSearchVisibility}
+              class="w-full md:w-auto px-6 py-3 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg transition-colors duration-200 flex items-center justify-center gap-2"
+            >
+              <svg
+                class={`w-5 h-5 transition-transform duration-200 ${
+                  isSearchVisible ? "rotate-180" : ""
+                }`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+              検索オプション
+            </button>
 
-          {isSearchVisible && (
-            <div class="p-4">
-              <div>
-                <label for="sortOrder">ソート順:</label>
-                <select
-                  id="sortOrder"
-                  value={sortOrder}
-                  onChange={handleSortOrderChange}
-                >
-                  <option value="desc">新しい順</option>
-                  <option value="asc">古い順</option>
-                </select>
-              </div>
-              <div>
-                <label for="sortField">ソート基準:</label>
-                <select
-                  id="sortField"
-                  value={sortField}
-                  onChange={handleSortFieldChange}
-                >
-                  <option value="newsDate">投稿日</option>
-                  <option value="updated">更新日</option>
-                </select>
-              </div>
-              <div>
-                <input
-                  type="radio"
-                  id="limit10"
-                  name="displayLimit"
-                  value="10"
-                  checked={selectedDisplayLimit === 10}
-                  onChange={handleSelectedDisplayLimitChange}
-                />
-                <label for="limit10">10件</label>
-                <input
-                  type="radio"
-                  id="limit50"
-                  name="displayLimit"
-                  value="50"
-                  checked={selectedDisplayLimit === 50}
-                  onChange={handleSelectedDisplayLimitChange}
-                />
-                <label for="limit50">50件</label>
-                <input
-                  type="radio"
-                  id="limit100"
-                  name="displayLimit"
-                  value="100"
-                  checked={selectedDisplayLimit === 100}
-                  onChange={handleSelectedDisplayLimitChange}
-                />
-                <label for="limit100">100件</label>
-                <input
-                  type="radio"
-                  id="limitAll"
-                  name="displayLimit"
-                  value="all"
-                  checked={selectedDisplayLimit === allNewsData.length}
-                  onChange={handleSelectedDisplayLimitChange}
-                />
-                <label for="limitAll">全件</label>
-              </div>
-              <div class="flex flex-col">
-                <div class="flex">
-                  <input
-                    type="text"
-                    class="p-2 m-2 border border-gray-600 rounded-md flex-grow"
-                    placeholder="(測定 OR 掃除) 開催 -予告"
-                    value={searchKeyword}
-                    onChange={handleSearchChange}
-                    onKeyDown={handleKeyDown}
-                  />
-                  <button
-                    class="p-2 m-2 border border-gray-600 rounded-md bg-blue-500 text-white"
-                    onClick={handleSearch}
+            {/* 検索欄 */}
+            <div
+              class={`transition-all duration-300 ease-in-out overflow-hidden ${
+                isSearchVisible ? "max-h-screen opacity-100" : "max-h-0 opacity-0"
+              }`}
+            >
+              <div class="bg-white p-3 rounded-lg shadow-md space-y-3">
+                {/* ソート順 */}
+                <div class="flex items-center gap-4">
+                  <label class="text-sm font-medium text-gray-700 whitespace-nowrap" for="sortOrder">
+                    ソート順:
+                  </label>
+                  <select
+                    id="sortOrder"
+                    value={sortOrder}
+                    onChange={handleSortOrderChange}
+                    class="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   >
-                    検索
-                  </button>
+                    <option value="desc">新しい順</option>
+                    <option value="asc">古い順</option>
+                  </select>
                 </div>
-              </div>
-              <div>
-                <div class="flex items-center">
-                  <div class="border border-gray-600 rounded-md p-2 m-2">
+
+                {/* 表示件数 */}
+                <div class="flex items-center gap-4">
+                  <label class="text-sm font-medium text-gray-700 whitespace-nowrap">
+                    表示件数:
+                  </label>
+                  <div class="flex flex-wrap gap-4">
+                    {[
+                      { id: "limit10", value: "10", label: "10件" },
+                      { id: "limit50", value: "50", label: "50件" },
+                      { id: "limit100", value: "100", label: "100件" },
+                      { id: "limitAll", value: "all", label: "全件" },
+                    ].map(({ id, value, label }) => (
+                      <div class="flex items-center space-x-2">
+                        <input
+                          type="radio"
+                          id={id}
+                          name="displayLimit"
+                          value={value}
+                          checked={
+                            value === "all"
+                              ? selectedDisplayLimit === allNewsData.length
+                              : selectedDisplayLimit === Number(value)
+                          }
+                          onChange={handleSelectedDisplayLimitChange}
+                          class="w-4 h-4 text-blue-500 focus:ring-blue-500"
+                        />
+                        <label
+                          for={id}
+                          class="text-sm text-gray-700 cursor-pointer"
+                        >
+                          {label}
+                        </label>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                {/* キーワード検索 */}
+                <div class="space-y-2">
+                  <label class="block text-sm font-medium text-gray-700">
+                    キーワード検索:
+                  </label>
+                  <div class="flex gap-2">
+                    <input
+                      type="text"
+                      class="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      placeholder="(測定 or 掃除) 開催 -予告"
+                      value={searchKeyword}
+                      onChange={handleSearchChange}
+                      onKeyDown={handleKeyDown}
+                    />
+                    <button
+                      onClick={handleSearch}
+                      class="px-6 py-2 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg transition-colors duration-200"
+                    >
+                      検索
+                    </button>
+                  </div>
+                </div>
+
+                {/* 日付範囲 */}
+                <div class="space-y-2">
+                  <label class="block text-sm font-medium text-gray-700">
+                    期間:
+                  </label>
+                  <div class="flex flex-wrap items-center gap-4">
                     <input
                       type="date"
                       id="startDate"
                       value={startDate}
                       onChange={handleStartDateChange}
+                      class="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     />
-                  </div>
-                  <span> ～ </span>
-                  <div class="border border-gray-600 rounded-md p-2 ml-2">
+                    <span class="text-gray-500">～</span>
                     <input
                       type="date"
                       id="endDate"
                       value={endDate}
                       onChange={handleEndDateChange}
+                      class="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     />
                   </div>
                 </div>
               </div>
             </div>
-          )}
 
-          <div class="p-2 m-2">
-            <span>おしらせの件数: {numberOfNews}件</span>
-          </div>
+            {/* お知らせヒット件数 */}
+            <div class="text-sm text-gray-600 font-medium mt-0">
+              おしらせの件数: {numberOfNews}件
+            </div>
 
-          <ul>
-            {newsData.map((news, index) => (
-              <li
-                key={index}
-                class="p-2 m-2 hover:shadow-xl border border-gray-600 rounded-md"
-              >
-                <a
-                  href={`https://kemono-friends-3.jp${news.targetUrl}`}
-                  target="_blank"
-                  class="flex flex-col justify-between"
+            {/* ニュースリスト */}
+            <ul class="space-y-4">
+              {newsData.map((news, index) => (
+                <li
+                  key={index}
+                  class="group bg-white hover:bg-blue-50 border border-gray-300 rounded-lg transition-all duration-200 hover:shadow-lg"
                 >
-                  <p class="min-h-16 overflow-hidden text-base">{news.title}</p>
-                  <span class="text-xs mt-auto">{news.newsDate.slice(0, 11)}</span>
-                </a>
-              </li>
-            ))}
-          </ul>
+                  <a
+                    href={`https://kemono-friends-3.jp${news.targetUrl}`}
+                    target="_blank"
+                    class="block p-4"
+                  >
+                    <p class="text-gray-800 group-hover:text-blue-600 transition-colors duration-200 mb-2">
+                      {news.title}
+                    </p>
+                    <time class="text-sm text-gray-500">
+                      {news.newsDate.slice(0, 11)}
+                    </time>
+                  </a>
+                </li>
+              ))}
+            </ul>
 
-          {numberOfNews > displayLimit && (
-            <button
-              class="p-2 m-2 border border-gray-600 rounded-md bg-blue-500 text-white"
-              onClick={handleLoadMore}
-            >
-              もっと見る
-            </button>
-          ) || null}
-        </>
-      )}
+            {/* もっと見るボタン */}
+            {numberOfNews > displayLimit && (
+              <div class="flex justify-center">
+                <button
+                  onClick={handleLoadMore}
+                  class="w-full md:w-96 px-6 py-3 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg transition-colors duration-200"
+                >
+                  もっと見る
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -39,6 +39,12 @@ const KemonoFriends3NewsSearch = () => {
           if (savedDisplayLimit) {
             setSelectedDisplayLimitString(savedDisplayLimit);
           }
+
+          // 検索欄の表示状態を設定
+          const savedSearchVisibility = localStorage.getItem("isSearchVisible");
+          if (savedSearchVisibility) {
+            setIsSearchVisible(savedSearchVisibility === "true");
+          }
         } else {
           console.error("Data validation failed", result.error);
         }
@@ -135,6 +141,7 @@ const KemonoFriends3NewsSearch = () => {
   // 検索欄の表示・非表示を切り替える
   const toggleSearchVisibility = () => {
     setIsSearchVisible((prev) => !prev);
+    localStorage.setItem("isSearchVisible", (!isSearchVisible).toString());
   };
 
   // ニュースデータをキーワードでフィルター
@@ -192,7 +199,7 @@ const KemonoFriends3NewsSearch = () => {
             <span class="ml-4 text-gray-600 font-medium">データを取得しています...</span>
           </div>
         ) : (
-          <div class="space-y-3">
+          <div class="space-y-3" >
             {/* 検索欄トグルボタン */}
             <button
               onClick={toggleSearchVisibility}

--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -192,7 +192,7 @@ const KemonoFriends3NewsSearch = () => {
             <span class="ml-4 text-gray-600 font-medium">データを取得しています...</span>
           </div>
         ) : (
-          <div class="space-y-6">
+          <div class="space-y-3">
             {/* 検索欄トグルボタン */}
             <button
               onClick={toggleSearchVisibility}
@@ -305,6 +305,7 @@ const KemonoFriends3NewsSearch = () => {
                   </div>
                 </div>
               </div>
+              <div class="border-t border-gray-300 my-4"></div>
             </div>
 
             {/* お知らせヒット件数 */}

--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -7,8 +7,9 @@ const KemonoFriends3NewsSearch = () => {
   const [newsData, setNewsData] = useState<Array<News>>([]); // 表示されるニュースデータ
   const [allNewsData, setAllNewsData] = useState<Array<News>>([]); // 全ニュースデータ
   const [searchKeyword, setSearchKeyword] = useState(""); // 検索キーワード
-  const [selectedDisplayLimit, setSelectedDisplayLimit] = useState(10); // 選択された表示件数
-  const [displayLimit, setDisplayLimit] = useState(10); // 表示件数
+  const [selectedDisplayLimitString, setSelectedDisplayLimitString] = useState<string>("10"); // 選択された表示件数(文字列)
+  const [selectedDisplayLimit, setSelectedDisplayLimit] = useState<number>(10); // 選択された表示件数(数値)
+  const [displayLimit, setDisplayLimit] = useState<number>(10); // 表示件数(数値、もっと見るボタンで加算)
   const [sortOrder, setSortOrder] = useState("desc"); // ソート順
   const [isSearchVisible, setIsSearchVisible] = useState(false); // 検索欄の表示状態
   const [startDate, setStartDate] = useState("2019-09-24"); // フィルター開始日
@@ -36,12 +37,7 @@ const KemonoFriends3NewsSearch = () => {
           // 表示件数を設定
           const savedDisplayLimit = localStorage.getItem("selectedDisplayLimit");
           if (savedDisplayLimit) {
-            const limit =
-              savedDisplayLimit === "all"
-                  ? sortedData.length
-                  : Number(savedDisplayLimit);
-            setSelectedDisplayLimit(limit);
-            setDisplayLimit(limit);
+            setSelectedDisplayLimitString(savedDisplayLimit);
           }
         } else {
           console.error("Data validation failed", result.error);
@@ -54,6 +50,16 @@ const KemonoFriends3NewsSearch = () => {
         setIsLoading(false);
       });
   }, []);
+
+  // 表示件数が変更されたときに表示件数を更新
+  useEffect(() => {
+    const newLimit =
+      selectedDisplayLimitString === "all"
+        ? Infinity
+        : Number(selectedDisplayLimitString);
+    setSelectedDisplayLimit(newLimit);
+    setDisplayLimit(newLimit);
+  }, [selectedDisplayLimitString]);
 
   // 検索キーワードを除く検索条件が変更されたときに検索を実行
   useEffect(() => {
@@ -120,13 +126,8 @@ const KemonoFriends3NewsSearch = () => {
 
   // 表示件数を変更する
   const handleSelectedDisplayLimitChange = (event: Event) => {
-    if (event.target instanceof HTMLInputElement) {
-      const newLimit =
-        event.target.value === "all"
-          ? allNewsData.length
-          : Number(event.target.value);
-      setSelectedDisplayLimit(newLimit);
-      setDisplayLimit(newLimit);
+    if (event.target instanceof HTMLSelectElement) {
+      setSelectedDisplayLimitString(event.target.value);
       localStorage.setItem("selectedDisplayLimit", event.target.value);
     }
   };
@@ -222,56 +223,38 @@ const KemonoFriends3NewsSearch = () => {
               }`}
             >
               <div class="bg-white p-3 rounded-lg shadow-md space-y-3">
-                {/* ソート順 */}
-                <div class="flex items-center gap-4">
-                  <label class="text-sm font-medium text-gray-700 whitespace-nowrap" for="sortOrder">
-                    ソート順:
-                  </label>
-                  <select
-                    id="sortOrder"
-                    value={sortOrder}
-                    onChange={handleSortOrderChange}
-                    class="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  >
-                    <option value="desc">新しい順</option>
-                    <option value="asc">古い順</option>
-                  </select>
-                </div>
+                {/* ソート順と表示件数 */}
+                <div class="flex flex-wrap items-center gap-4">
+                  <div class="flex items-center gap-2">
+                    <label class="text-sm font-medium text-gray-700 whitespace-nowrap" for="sortOrder">
+                      ソート順:
+                    </label>
+                    <select
+                      id="sortOrder"
+                      value={sortOrder}
+                      onChange={handleSortOrderChange}
+                      class="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    >
+                      <option value="desc">新しい順</option>
+                      <option value="asc">古い順</option>
+                    </select>
+                  </div>
 
-                {/* 表示件数 */}
-                <div class="flex items-center gap-4">
-                  <label class="text-sm font-medium text-gray-700 whitespace-nowrap">
-                    表示件数:
-                  </label>
-                  <div class="flex flex-wrap gap-4">
-                    {[
-                      { id: "limit10", value: "10", label: "10件" },
-                      { id: "limit50", value: "50", label: "50件" },
-                      { id: "limit100", value: "100", label: "100件" },
-                      { id: "limitAll", value: "all", label: "全件" },
-                    ].map(({ id, value, label }) => (
-                      <div class="flex items-center space-x-2">
-                        <input
-                          type="radio"
-                          id={id}
-                          name="displayLimit"
-                          value={value}
-                          checked={
-                            value === "all"
-                              ? selectedDisplayLimit === allNewsData.length
-                              : selectedDisplayLimit === Number(value)
-                          }
-                          onChange={handleSelectedDisplayLimitChange}
-                          class="w-4 h-4 text-blue-500 focus:ring-blue-500"
-                        />
-                        <label
-                          for={id}
-                          class="text-sm text-gray-700 cursor-pointer"
-                        >
-                          {label}
-                        </label>
-                      </div>
-                    ))}
+                  <div class="flex items-center gap-2">
+                    <label class="text-sm font-medium text-gray-700 whitespace-nowrap" for="displayLimit">
+                      表示件数:
+                    </label>
+                    <select
+                      id="displayLimit"
+                      value={selectedDisplayLimit === Infinity ? "all" : selectedDisplayLimit.toString()}
+                      onChange={handleSelectedDisplayLimitChange}
+                      class="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    >
+                      <option value="10">10件</option>
+                      <option value="50">50件</option>
+                      <option value="100">100件</option>
+                      <option value="all">全件</option>
+                    </select>
                   </div>
                 </div>
 

--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -193,7 +193,7 @@ const KemonoFriends3NewsSearch = () => {
           </div>
         ) : (
           <div class="space-y-6">
-            {/* Search Toggle Button */}
+            {/* 検索欄トグルボタン */}
             <button
               onClick={toggleSearchVisibility}
               class="w-full md:w-auto px-6 py-3 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg transition-colors duration-200 flex items-center justify-center gap-2"
@@ -222,7 +222,7 @@ const KemonoFriends3NewsSearch = () => {
                 isSearchVisible ? "max-h-screen opacity-100" : "max-h-0 opacity-0"
               }`}
             >
-              <div class="bg-white p-3 rounded-lg shadow-md space-y-3">
+              <div class="bg-white p-1 rounded-lg space-y-3">
                 {/* ソート順と表示件数 */}
                 <div class="flex flex-wrap items-center gap-4">
                   <div class="flex items-center gap-2">
@@ -233,7 +233,7 @@ const KemonoFriends3NewsSearch = () => {
                       id="sortOrder"
                       value={sortOrder}
                       onChange={handleSortOrderChange}
-                      class="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      class="px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     >
                       <option value="desc">新しい順</option>
                       <option value="asc">古い順</option>
@@ -248,7 +248,7 @@ const KemonoFriends3NewsSearch = () => {
                       id="displayLimit"
                       value={selectedDisplayLimit === Infinity ? "all" : selectedDisplayLimit.toString()}
                       onChange={handleSelectedDisplayLimitChange}
-                      class="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      class="px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     >
                       <option value="10">10件</option>
                       <option value="50">50件</option>
@@ -259,14 +259,14 @@ const KemonoFriends3NewsSearch = () => {
                 </div>
 
                 {/* キーワード検索 */}
-                <div class="space-y-2">
-                  <label class="block text-sm font-medium text-gray-700">
+                <div className="space-y-2">
+                  <label className="block text-sm font-medium text-gray-700">
                     キーワード検索:
                   </label>
-                  <div class="flex gap-2">
+                  <div className="flex flex-wrap gap-2">
                     <input
                       type="text"
-                      class="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      className="flex-1 min-w-[200px] px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                       placeholder="(測定 or 掃除) 開催 -予告"
                       value={searchKeyword}
                       onChange={handleSearchChange}
@@ -274,7 +274,7 @@ const KemonoFriends3NewsSearch = () => {
                     />
                     <button
                       onClick={handleSearch}
-                      class="px-6 py-2 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg transition-colors duration-200"
+                      className="px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg transition-colors duration-200"
                     >
                       検索
                     </button>
@@ -286,13 +286,13 @@ const KemonoFriends3NewsSearch = () => {
                   <label class="block text-sm font-medium text-gray-700">
                     期間:
                   </label>
-                  <div class="flex flex-wrap items-center gap-4">
+                  <div class="flex flex-wrap items-center gap-2">
                     <input
                       type="date"
                       id="startDate"
                       value={startDate}
                       onChange={handleStartDateChange}
-                      class="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      class="px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     />
                     <span class="text-gray-500">～</span>
                     <input
@@ -300,7 +300,7 @@ const KemonoFriends3NewsSearch = () => {
                       id="endDate"
                       value={endDate}
                       onChange={handleEndDateChange}
-                      class="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      class="px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     />
                   </div>
                 </div>

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -5,7 +5,7 @@ export default createRoute((c) => {
   const name = "けもフレ３おしらせ検索";
   return c.render(
     <div class="flex flex-col">
-      <h1 class="text-4xl font-bold p-4">{name}</h1>
+      <h1 class="text-4xl font-bold p-4 pb-0">{name}</h1>
       <KemonoFriends3 />
     </div>,
     { title: name }


### PR DESCRIPTION
## 変更点
### 機能敵な変更
- ソート基準の選択肢を削除
  - → `newsDate`と`updated`の値の日付部分は同一である(時間の情報が含まれているかどうかの違いしかない)ため、時間の情報も含んでいる`newsDate`のみで十分と思われるため
- 表示件数の選択をラジオボタンからプルダウンリストに変更
- 検索欄の表示/非表示状態をページ再読み込み後も保持

### スタイルの調整
- プルダウンリスト
  - ボーダーを追加
- 検索欄トグルボタン
  - 矢印(∧/∨)のアイコンを追加
  - テキストを変更(「検索欄を(非)表示」→「検索オプション」)
  - トグル時アニメーションを追加
- 検索欄トグルボタンともっと見るボタン
  - 画面横幅が大きい場合、ボタン横幅を固定
  - ホバー時に背景色を濃く
  - ボーダーのコントラストを下げる
- 検索欄の下に境界線を追加
- お知らせ件数
  - フォントサイズを小さく
  - フォント色を薄く
- ニュースリスト
  - パディングを大きめに
  - ホバー時の背景色を設定
  - 日付のフォントサイズを大きく、フォント色を薄く
- その他余白の調整

スタイルの調整は私の主観によるところが大きいため、お好みと合わなかったらごめんなさい🙇‍♂️

### イメージ
| 変更前 | 変更後 |
|---|---|
| ![変更前イメージ](https://github.com/user-attachments/assets/d139aa12-1a5a-49c1-96ee-349fdfb55658) | ![変更後イメージ](https://github.com/user-attachments/assets/f3b9d2ba-5138-4242-82c8-b1ca8f121b6e) |

## 確認項目
- ページを再読み込み時、検索欄の表示/非表示状態が保持されていることを確認
- 表示件数の選択が正常に動作していることを確認
  - 設定した件数のニュースが表示されていること
  - もっと見るボタン押下時やページ再読み込み時に、件数の選択状態が保持されていること
- スタイルの調整に問題がないか確認