### PR TITLE
日本時間に対応させる

### DIFF
--- a/app/__tests__/get-japanese-date.test.ts
+++ b/app/__tests__/get-japanese-date.test.ts
@@ -1,0 +1,38 @@
+import { getJapaneseDate } from "../get-japanese-date";
+import dayjs from "dayjs";
+import "dayjs/locale/ja";
+
+function test(testName: string, fn: () => boolean) {
+  try {
+    const result = fn();
+    console.log(`${result ? "✅" : "❌"} ${testName}`);
+  } catch (error) {
+    console.log(`❌ ${testName}`);
+    console.error(" ", error);
+  }
+}
+
+export function runTests() {
+  const UtcDateMock = "2021-12-31T15:00:00Z"; // 日本時間とUTCとの差が9時間のため、日本時間で2022-01-01になる
+  test("日本時間が正しく表示されるか", () => {
+    dayjs.locale("ja");
+    const expected = dayjs(UtcDateMock).format("YYYY-MM-DD"); // 2022-01-01
+    const actual = getJapaneseDate(UtcDateMock); // 2022-01-01
+    return expected === actual;
+  });
+
+  test("Date関数とgetJapaneseDateの結果が異なるか", () => {
+    const expected = new Date(UtcDateMock).toISOString().split("T")[0]; // 2021-12-31
+    const actual = getJapaneseDate(UtcDateMock); // 2022-01-01
+    return expected !== actual;
+  });
+
+  test("現在日時が返るか", () => {
+    const expected = dayjs().format("YYYY-MM-DD");
+    const actual = getJapaneseDate();
+    return expected === actual;
+  });
+}
+
+console.log("get-japanese-date Tests:");
+runTests();

--- a/app/__tests__/get-japanese-date.test.ts
+++ b/app/__tests__/get-japanese-date.test.ts
@@ -32,6 +32,20 @@ export function runTests() {
     const actual = getJapaneseDate();
     return expected === actual;
   });
+
+  test("DateオブジェクトとgetJapaneseDateでギリギリ日付が変わるケース", () => {
+    const UtcDateMock = "2021-12-31T15:00:00Z"; // 日本時間でギリギリ2022-01-01になる
+    const expected = new Date(UtcDateMock).toISOString().split("T")[0]; // 2021-12-31
+    const actual = getJapaneseDate(UtcDateMock); // 2022-01-01
+    return expected !== actual;
+  });
+
+  test("DateオブジェクトとgetJapaneseDateでギリギリ日付が変わらないケース", () => {
+    const UtcDateMock = "2021-12-31T14:59:59Z"; // 日本時間でギリギリ2021-12-31になる
+    const expected = new Date(UtcDateMock).toISOString().split("T")[0]; // 2021-12-31
+    const actual = getJapaneseDate(UtcDateMock); // 2021-12-31
+    return expected === actual;
+  });
 }
 
 console.log("get-japanese-date Tests:");

--- a/app/get-japanese-date.ts
+++ b/app/get-japanese-date.ts
@@ -1,0 +1,11 @@
+import dayjs from "dayjs";
+import "dayjs/locale/ja";
+
+dayjs.locale("ja");
+
+export const getJapaneseDate = (date?: string) => {
+  if (!date) {
+    return dayjs().format("YYYY-MM-DD");
+  }
+  return dayjs(date).format("YYYY-MM-DD");
+};

--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useState } from "hono/jsx";
 import { newsArraySchema, News } from "../schema";
 import { QueryParser } from "../query-parser";
-import dayjs from 'dayjs';
-import 'dayjs/locale/ja';
-
-dayjs.locale('ja');
+import { getJapaneseDate } from "../get-japanese-date";
 
 
 // ニュースデータの検索・表示コンポーネント
@@ -18,7 +15,7 @@ const KemonoFriends3NewsSearch = () => {
   const [sortField, setSortField] = useState("newsDate"); // ソート基準
   const [isSearchVisible, setIsSearchVisible] = useState(false); // 検索欄の表示状態
   const [startDate, setStartDate] = useState("2019-09-24"); // フィルター開始日
-  const [endDate, setEndDate] = useState(dayjs().format('YYYY-MM-DD')); // フィルター終了日
+  const [endDate, setEndDate] = useState(getJapaneseDate()); // フィルター終了日
   const [numberOfNews, setNumberOfNews] = useState(0); // ニュースの数
   const [isLoading, setIsLoading] = useState(true); // データ取得中の状態
 

--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from "hono/jsx";
 import { newsArraySchema, News } from "../schema";
 import { QueryParser } from "../query-parser";
+import dayjs from 'dayjs';
+import 'dayjs/locale/ja';
+
+dayjs.locale('ja');
+
 
 // ニュースデータの検索・表示コンポーネント
 const KemonoFriends3NewsSearch = () => {
@@ -13,7 +18,7 @@ const KemonoFriends3NewsSearch = () => {
   const [sortField, setSortField] = useState("newsDate"); // ソート基準
   const [isSearchVisible, setIsSearchVisible] = useState(false); // 検索欄の表示状態
   const [startDate, setStartDate] = useState("2019-09-24"); // フィルター開始日
-  const [endDate, setEndDate] = useState(new Date().toISOString().split("T")[0]); // フィルター終了日
+  const [endDate, setEndDate] = useState(dayjs().format('YYYY-MM-DD')); // フィルター終了日
   const [numberOfNews, setNumberOfNews] = useState(0); // ニュースの数
   const [isLoading, setIsLoading] = useState(true); // データ取得中の状態
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "vite build --mode client && vite build",
     "preview": "wrangler pages dev",
     "deploy": "$npm_execpath run build && wrangler pages deploy",
-    "test": "vite-node ./app/__tests__/query-parser.test.ts"
+    "test": "vite-node ./app/__tests__/query-parser.test.ts && vite-node ./app/__tests__/get-japanese-date.test.ts"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@hono/vite-cloudflare-pages": "^0.4.2",
     "@hono/vite-ssg": "^0.1.0",
+    "dayjs": "^1.11.13",
     "hono": "^4.6.11",
     "honox": "^0.1.26"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,4 +13,7 @@ export default defineConfig({
     }),
     build(),
   ],
+  ssr: {
+    external: ["dayjs"],
+  },
 });


### PR DESCRIPTION
## 概要

- フィルタの終了日時がUTCの日付になっていたので、 dayjs を使って日本時間に対応させます。

## 実装詳細

- フィルター終了日の初期値である`new Date().toISOString().split("T")[0]`がUTCの日付だったので、dayjsを使った`getJapaneseDate`関数で現在の日本の時刻を取得するよう変更しました。
- toLocaleDateStringとreplaceを使う方法もありますが、`2022/01/01`にならない（`2022/1/1`になる）ので、dayjsを使いました。

## 確認方法

- テストを追加したので、テストが通ること。