### PR TITLE
selectタグと日付のinputタグの見た目をプラットフォーム間で統一

### DIFF
--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -316,7 +316,7 @@ const KemonoFriends3NewsSearch = () => {
                       id="startDate"
                       value={startDate}
                       onChange={handleStartDateChange}
-                      class="px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      class="px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none"
                     />
                     <span class="text-gray-500">～</span>
                     <input
@@ -324,7 +324,7 @@ const KemonoFriends3NewsSearch = () => {
                       id="endDate"
                       value={endDate}
                       onChange={handleEndDateChange}
-                      class="px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      class="px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none"
                     />
                   </div>
                 </div>

--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -239,32 +239,46 @@ const KemonoFriends3NewsSearch = () => {
                     <label class="text-sm font-medium text-gray-700 whitespace-nowrap" for="sortOrder">
                       ソート順:
                     </label>
-                    <select
-                      id="sortOrder"
-                      value={sortOrder}
-                      onChange={handleSortOrderChange}
-                      class="px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                    >
-                      <option value="desc">新しい順</option>
-                      <option value="asc">古い順</option>
-                    </select>
+                    <div className="relative">
+                      <select
+                        id="sortOrder"
+                        value={sortOrder}
+                        onChange={handleSortOrderChange}
+                        className="w-full pl-4 pr-8 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none"
+                      >
+                        <option value="desc">新しい順</option>
+                        <option value="asc">古い順</option>
+                      </select>
+                      <div className="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none">
+                        <svg className="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                      </div>
+                    </div>
                   </div>
 
                   <div class="flex items-center gap-2">
                     <label class="text-sm font-medium text-gray-700 whitespace-nowrap" for="displayLimit">
                       表示件数:
                     </label>
-                    <select
-                      id="displayLimit"
-                      value={selectedDisplayLimit === Infinity ? "all" : selectedDisplayLimit.toString()}
-                      onChange={handleSelectedDisplayLimitChange}
-                      class="px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                    >
-                      <option value="10">10件</option>
-                      <option value="50">50件</option>
-                      <option value="100">100件</option>
-                      <option value="all">全件</option>
-                    </select>
+                    <div className="relative">
+                      <select
+                        id="displayLimit"
+                        value={selectedDisplayLimit === Infinity ? "all" : selectedDisplayLimit.toString()}
+                        onChange={handleSelectedDisplayLimitChange}
+                        className="w-full pl-4 pr-8 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none"
+                      >
+                        <option value="10">10件</option>
+                        <option value="50">50件</option>
+                        <option value="100">100件</option>
+                        <option value="all">全件</option>
+                      </select>
+                      <div className="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none">
+                        <svg className="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                      </div>
+                    </div>
                   </div>
                 </div>
 


### PR DESCRIPTION
プラットフォーム間で(特にSafariが他と)selectタグと日付のinputタグの見た目が異なるので統一しました。
Safari(iPhone)での修正前後のイメージ:
| 修正前 | 修正後 |
|---|---|
| ![修正前](https://github.com/user-attachments/assets/2d0c5f41-a29c-480a-aad1-adf5fc04d6cf) | ![修正後](https://github.com/user-attachments/assets/1c5d77a9-e068-4171-b666-0b7131ffb1d8) |