### PR TITLE
キーワード検索においてアルファベットの大文字/小文字、全角/半角、カタカナ/ひらがなの違いを無視

### DIFF
--- a/app/__tests__/query-normalizer.test.ts
+++ b/app/__tests__/query-normalizer.test.ts
@@ -3,47 +3,47 @@
 import { normalizeQuery } from '../query-normalizer';
 
 function test(testName: string, fn: () => boolean) {
-	try {
-		const result = fn();
-		console.log(`${result ? '✅' : '❌'} ${testName}`);
-	} catch (error) {
-		console.log(`❌ ${testName}`);
-		console.error(' ', error);
-	}
+  try {
+    const result = fn();
+    console.log(`${result ? '✅' : '❌'} ${testName}`);
+  } catch (error) {
+    console.log(`❌ ${testName}`);
+    console.error(' ', error);
+  }
 }
 
 export function runTests() {
-	// 半角アルファベットの大文字小文字の変換
-	test('半角アルファベットの大文字小文字の変換', () => {
-		const query = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-		const expected = 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz';
-		const actual = normalizeQuery(query);
-		return actual === expected
-	});
+  // 半角アルファベットの大文字小文字の変換
+  test('半角アルファベットの大文字小文字の変換', () => {
+    const query = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const expected = 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz';
+    const actual = normalizeQuery(query);
+    return actual === expected
+  });
 
-	// 全角英数字と記号類の変換
-	test('全角英数字と記号類の変換(カッコだけそのまま)', () => {
-		const query = '！＂＃＄％＆＇（）＊＋，－．／０１２３４５６７８９：；＜＝＞？＠ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ［＼］＾＿｀ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ｛｜｝～';
-		const expected = '!"#$%&\'（）*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-		const actual = normalizeQuery(query);
-		return actual === expected;
-	});
+  // 全角英数字と記号類の変換
+  test('全角英数字と記号類の変換(カッコだけそのまま)', () => {
+    const query = '！＂＃＄％＆＇（）＊＋，－．／０１２３４５６７８９：；＜＝＞？＠ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ［＼］＾＿｀ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ｛｜｝～';
+    const expected = '!"#$%&\'（）*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
+    const actual = normalizeQuery(query);
+    return actual === expected;
+  });
 
-	// カタカナの変換
-	test('カタカナの変換', () => {
-		const query = 'あアいイうウえエおオ　らラりリるルれレろロ　ぁァがパぃィぅゥづプぇェぉォじピゃャじュょョっッ';
-		const expected = 'ああいいううええおお　ららりりるるれれろろ　ぁぁがぱぃぃぅぅづぷぇぇぉぉじぴゃゃじゅょょっっ';
-		const actual = normalizeQuery(query);
-		return actual === expected;
-	});
+  // カタカナの変換
+  test('カタカナの変換', () => {
+    const query = 'あアいイうウえエおオ　らラりリるルれレろロ　ぁァがパぃィぅゥづプぇェぉォじピゃャじュょョっッ';
+    const expected = 'ああいいううええおお　ららりりるるれれろろ　ぁぁがぱぃぃぅぅづぷぇぇぉぉじぴゃゃじゅょょっっ';
+    const actual = normalizeQuery(query);
+    return actual === expected;
+  });
 
-	// 余分なスペースの削除
-	test('余分なスペースの削除', () => {
-		const query = '　 　 あイう　　  ';
-		const expected = 'あいう';
-		const actual = normalizeQuery(query);
-		return actual === expected;
-	});
+  // 余分なスペースの削除
+  test('余分なスペースの削除', () => {
+    const query = '　 　 あイう　　  ';
+    const expected = 'あいう';
+    const actual = normalizeQuery(query);
+    return actual === expected;
+  });
 }
 
 // テストの実行

--- a/app/__tests__/query-normalizer.test.ts
+++ b/app/__tests__/query-normalizer.test.ts
@@ -1,0 +1,51 @@
+// 簡易のテストケース
+
+import { normalizeQuery } from '../query-normalizer';
+
+function test(testName: string, fn: () => boolean) {
+	try {
+		const result = fn();
+		console.log(`${result ? '✅' : '❌'} ${testName}`);
+	} catch (error) {
+		console.log(`❌ ${testName}`);
+		console.error(' ', error);
+	}
+}
+
+export function runTests() {
+	// 半角アルファベットの大文字小文字の変換
+	test('半角アルファベットの大文字小文字の変換', () => {
+		const query = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		const expected = 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz';
+		const actual = normalizeQuery(query);
+		return actual === expected
+	});
+
+	// 全角英数字と記号類の変換
+	test('全角英数字と記号類の変換(カッコだけそのまま)', () => {
+		const query = '！＂＃＄％＆＇（）＊＋，－．／０１２３４５６７８９：；＜＝＞？＠ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ［＼］＾＿｀ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ｛｜｝～';
+		const expected = '!"#$%&\'（）*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
+		const actual = normalizeQuery(query);
+		return actual === expected;
+	});
+
+	// カタカナの変換
+	test('カタカナの変換', () => {
+		const query = 'あアいイうウえエおオ　らラりリるルれレろロ　ぁァがパぃィぅゥづプぇェぉォじピゃャじュょョっッ';
+		const expected = 'ああいいううええおお　ららりりるるれれろろ　ぁぁがぱぃぃぅぅづぷぇぇぉぉじぴゃゃじゅょょっっ';
+		const actual = normalizeQuery(query);
+		return actual === expected;
+	});
+
+	// 余分なスペースの削除
+	test('余分なスペースの削除', () => {
+		const query = '　 　 あイう　　  ';
+		const expected = 'あいう';
+		const actual = normalizeQuery(query);
+		return actual === expected;
+	});
+}
+
+// テストの実行
+console.log('Query Normalizer Tests:');
+runTests();

--- a/app/islands/KemonoFriends3NewsSearch.tsx
+++ b/app/islands/KemonoFriends3NewsSearch.tsx
@@ -204,183 +204,183 @@ const KemonoFriends3NewsSearch = () => {
   return (
     <div class="min-h-screen bg-yellow-400 px-4">
       <div class="max-w-6xl mx-auto bg-white shadow-lg rounded-lg p-6 my-4">
-          <div class={`flex justify-center items-center p-8 ${isLoading ? "" : "hidden"}`}>
-            <div class="w-8 h-8 border-4 border-blue-200 border-t-blue-500 rounded-full animate-spin"></div>
-            <span class="ml-4 text-gray-600 font-medium">データを取得しています...</span>
-          </div>
+        <div class={`flex justify-center items-center p-8 ${isLoading ? "" : "hidden"}`}>
+          <div class="w-8 h-8 border-4 border-blue-200 border-t-blue-500 rounded-full animate-spin"></div>
+          <span class="ml-4 text-gray-600 font-medium">データを取得しています...</span>
+        </div>
 
-          <div class={`space-y-3 ${isLoading ? "hidden" : ""}`} >
-            {/* 検索欄トグルボタン */}
-            <button
-              onClick={toggleSearchVisibility}
-              class={`w-full md:w-auto px-6 py-3 text-white font-medium rounded-lg transition-colors duration-200 flex items-center justify-center gap-2 ${
-                isSearchVisible ? "bg-gray-500 hover:bg-gray-600" : "bg-blue-500 hover:bg-blue-600"
+        <div class={`space-y-3 ${isLoading ? "hidden" : ""}`} >
+          {/* 検索欄トグルボタン */}
+          <button
+            onClick={toggleSearchVisibility}
+            class={`w-full md:w-auto px-6 py-3 text-white font-medium rounded-lg transition-colors duration-200 flex items-center justify-center gap-2 ${
+              isSearchVisible ? "bg-gray-500 hover:bg-gray-600" : "bg-blue-500 hover:bg-blue-600"
+            }`}
+          >
+            <svg
+              class={`w-5 h-5 transition-transform duration-200 ${
+                isSearchVisible ? "rotate-180" : ""
               }`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
             >
-              <svg
-                class={`w-5 h-5 transition-transform duration-200 ${
-                  isSearchVisible ? "rotate-180" : ""
-                }`}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M19 9l-7 7-7-7"
-                />
-              </svg>
-              検索オプション
-            </button>
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+            検索オプション
+          </button>
 
-            {/* 検索欄 */}
-            <div
-              class={`transition-all duration-300 ease-in-out overflow-hidden ${
-                isSearchVisible ? "max-h-screen opacity-100" : "max-h-0 opacity-0"
-              }`}
-            >
-              <div class="bg-white p-1 rounded-lg space-y-3">
-                {/* ソート順と表示件数 */}
-                <div class="flex flex-wrap items-center gap-4">
-                  <div class="flex items-center gap-2">
-                    <label class="text-sm font-medium text-gray-700 whitespace-nowrap" for="sortOrder">
-                      ソート順:
-                    </label>
-                    <div className="relative">
-                      <select
-                        id="sortOrder"
-                        value={sortOrder}
-                        onChange={handleSortOrderChange}
-                        className="w-full pl-4 pr-8 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none"
-                      >
-                        <option value="desc">新しい順</option>
-                        <option value="asc">古い順</option>
-                      </select>
-                      <div className="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none">
-                        <svg className="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div class="flex items-center gap-2">
-                    <label class="text-sm font-medium text-gray-700 whitespace-nowrap" for="displayLimit">
-                      表示件数:
-                    </label>
-                    <div className="relative">
-                      <select
-                        id="displayLimit"
-                        value={selectedDisplayLimit === Infinity ? "all" : selectedDisplayLimit.toString()}
-                        onChange={handleSelectedDisplayLimitChange}
-                        className="w-full pl-4 pr-8 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none"
-                      >
-                        <option value="10">10件</option>
-                        <option value="50">50件</option>
-                        <option value="100">100件</option>
-                        <option value="all">全件</option>
-                      </select>
-                      <div className="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none">
-                        <svg className="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                {/* キーワード検索 */}
-                <div className="space-y-2">
-                  <label className="block text-sm font-medium text-gray-700">
-                    キーワード検索:
+          {/* 検索欄 */}
+          <div
+            class={`transition-all duration-300 ease-in-out overflow-hidden ${
+              isSearchVisible ? "max-h-screen opacity-100" : "max-h-0 opacity-0"
+            }`}
+          >
+            <div class="bg-white p-1 rounded-lg space-y-3">
+              {/* ソート順と表示件数 */}
+              <div class="flex flex-wrap items-center gap-4">
+                <div class="flex items-center gap-2">
+                  <label class="text-sm font-medium text-gray-700 whitespace-nowrap" for="sortOrder">
+                    ソート順:
                   </label>
-                  <div className="flex flex-wrap gap-2">
-                    <input
-                      type="text"
-                      className="flex-1 min-w-[200px] px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                      placeholder="(測定 or 掃除) 開催 -予告"
-                      value={searchKeyword}
-                      onChange={handleSearchChange}
-                      onKeyDown={handleKeyDown}
-                    />
-                    <button
-                      onClick={handleSearch}
-                      className="px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg transition-colors duration-200"
+                  <div className="relative">
+                    <select
+                      id="sortOrder"
+                      value={sortOrder}
+                      onChange={handleSortOrderChange}
+                      className="w-full pl-4 pr-8 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none"
                     >
-                      検索
-                    </button>
+                      <option value="desc">新しい順</option>
+                      <option value="asc">古い順</option>
+                    </select>
+                    <div className="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none">
+                      <svg className="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+                      </svg>
+                    </div>
                   </div>
                 </div>
 
-                {/* 日付範囲 */}
-                <div class="space-y-2">
-                  <label class="block text-sm font-medium text-gray-700">
-                    期間:
+                <div class="flex items-center gap-2">
+                  <label class="text-sm font-medium text-gray-700 whitespace-nowrap" for="displayLimit">
+                    表示件数:
                   </label>
-                  <div class="flex flex-wrap items-center gap-2">
-                    <input
-                      type="date"
-                      id="startDate"
-                      value={startDate}
-                      onChange={handleStartDateChange}
-                      class="px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none"
-                    />
-                    <span class="text-gray-500">～</span>
-                    <input
-                      type="date"
-                      id="endDate"
-                      value={endDate}
-                      onChange={handleEndDateChange}
-                      class="px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none"
-                    />
+                  <div className="relative">
+                    <select
+                      id="displayLimit"
+                      value={selectedDisplayLimit === Infinity ? "all" : selectedDisplayLimit.toString()}
+                      onChange={handleSelectedDisplayLimitChange}
+                      className="w-full pl-4 pr-8 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none"
+                    >
+                      <option value="10">10件</option>
+                      <option value="50">50件</option>
+                      <option value="100">100件</option>
+                      <option value="all">全件</option>
+                    </select>
+                    <div className="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none">
+                      <svg className="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+                      </svg>
+                    </div>
                   </div>
                 </div>
               </div>
-              <div class="border-t border-gray-300 my-4"></div>
-            </div>
 
-            {/* お知らせヒット件数 */}
-            <div class="text-sm text-gray-600 font-medium mt-0">
-              おしらせの件数: {numberOfNews}件
-            </div>
-
-            {/* ニュースリスト */}
-            <ul class="space-y-4">
-              {newsData.map((news, index) => (
-                <li
-                  key={index}
-                  class="group bg-white hover:bg-blue-50 border border-gray-300 rounded-lg transition-all duration-200 hover:shadow-lg"
-                >
-                  <a
-                    href={`https://kemono-friends-3.jp${news.targetUrl}`}
-                    target="_blank"
-                    class="block p-4"
+              {/* キーワード検索 */}
+              <div className="space-y-2">
+                <label className="block text-sm font-medium text-gray-700">
+                  キーワード検索:
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  <input
+                    type="text"
+                    className="flex-1 min-w-[200px] px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="(測定 or 掃除) 開催 -予告"
+                    value={searchKeyword}
+                    onChange={handleSearchChange}
+                    onKeyDown={handleKeyDown}
+                  />
+                  <button
+                    onClick={handleSearch}
+                    className="px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg transition-colors duration-200"
                   >
-                    <p class="text-gray-800 group-hover:text-blue-600 transition-colors duration-200 mb-2">
-                      {news.title}
-                    </p>
-                    <time class="text-sm text-gray-500">
-                      {news.newsDate.slice(0, 11)}
-                    </time>
-                  </a>
-                </li>
-              ))}
-            </ul>
-
-            {/* もっと見るボタン */}
-            {numberOfNews > displayLimit && (
-              <div class="flex justify-center">
-                <button
-                  onClick={handleLoadMore}
-                  class="w-full md:w-96 px-6 py-3 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg transition-colors duration-200"
-                >
-                  もっと見る
-                </button>
+                    検索
+                  </button>
+                </div>
               </div>
-            )}
+
+              {/* 日付範囲 */}
+              <div class="space-y-2">
+                <label class="block text-sm font-medium text-gray-700">
+                  期間:
+                </label>
+                <div class="flex flex-wrap items-center gap-2">
+                  <input
+                    type="date"
+                    id="startDate"
+                    value={startDate}
+                    onChange={handleStartDateChange}
+                    class="px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none"
+                  />
+                  <span class="text-gray-500">～</span>
+                  <input
+                    type="date"
+                    id="endDate"
+                    value={endDate}
+                    onChange={handleEndDateChange}
+                    class="px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none"
+                  />
+                </div>
+              </div>
+            </div>
+            <div class="border-t border-gray-300 my-4"></div>
           </div>
+
+          {/* お知らせヒット件数 */}
+          <div class="text-sm text-gray-600 font-medium mt-0">
+            おしらせの件数: {numberOfNews}件
+          </div>
+
+          {/* ニュースリスト */}
+          <ul class="space-y-4">
+            {newsData.map((news, index) => (
+              <li
+                key={index}
+                class="group bg-white hover:bg-blue-50 border border-gray-300 rounded-lg transition-all duration-200 hover:shadow-lg"
+              >
+                <a
+                  href={`https://kemono-friends-3.jp${news.targetUrl}`}
+                  target="_blank"
+                  class="block p-4"
+                >
+                  <p class="text-gray-800 group-hover:text-blue-600 transition-colors duration-200 mb-2">
+                    {news.title}
+                  </p>
+                  <time class="text-sm text-gray-500">
+                    {news.newsDate.slice(0, 11)}
+                  </time>
+                </a>
+              </li>
+            ))}
+          </ul>
+
+          {/* もっと見るボタン */}
+          {numberOfNews > displayLimit && (
+            <div class="flex justify-center">
+              <button
+                onClick={handleLoadMore}
+                class="w-full md:w-96 px-6 py-3 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg transition-colors duration-200"
+              >
+                もっと見る
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/app/query-normalizer.ts
+++ b/app/query-normalizer.ts
@@ -2,25 +2,25 @@
 // 全角英数字・記号の変換マップ
 const zenkakuToHankakuMap: Map<string, string> = new Map();
 const initZenkakuToHankakuMap = (): void => {
-	for (let i = 0; i < 95; i++) {
-		const zenkaku = String.fromCharCode(0xFF01 + i);
-		const hankaku = String.fromCharCode(0x21 + i);
-		if (zenkaku === '（' || zenkaku === '）') {
-			// カッコは演算順序制御と競合するため変換しない
-			continue;
-		}
-		zenkakuToHankakuMap.set(zenkaku, hankaku);
-	}
+  for (let i = 0; i < 95; i++) {
+    const zenkaku = String.fromCharCode(0xFF01 + i);
+    const hankaku = String.fromCharCode(0x21 + i);
+    if (zenkaku === '（' || zenkaku === '）') {
+      // カッコは演算順序制御と競合するため変換しない
+      continue;
+    }
+    zenkakuToHankakuMap.set(zenkaku, hankaku);
+  }
 };
 
 // カタカナ→ひらがなの変換マップ
 const katakanaToHiraganaMap: Map<string, string> = new Map();
 const initKatakanaToHiraganaMap = (): void => {
-	for (let i = 0; i < 86; i++) {
-		const katakana = String.fromCharCode(0x30A1 + i);
-		const hiragana = String.fromCharCode(0x3041 + i);
-		katakanaToHiraganaMap.set(katakana, hiragana);
-	}
+  for (let i = 0; i < 86; i++) {
+    const katakana = String.fromCharCode(0x30A1 + i);
+    const hiragana = String.fromCharCode(0x3041 + i);
+    katakanaToHiraganaMap.set(katakana, hiragana);
+  }
 };
 
 // マップの初期化を一度だけ実行
@@ -33,31 +33,31 @@ initKatakanaToHiraganaMap();
  * @returns 変換後のテキスト
  */
 export function normalizeQuery(text: string): string {
-	text = text.trim();
+  text = text.trim();
 
-	const len = text.length;
-	const result = new Array<string>(len);
+  const len = text.length;
+  const result = new Array<string>(len);
 
-	for (let i = 0; i < len; i++) {
-		const char = text[i];
+  for (let i = 0; i < len; i++) {
+    const char = text[i];
 
-		// 全角英数字・記号の変換
-		const halfWidth = zenkakuToHankakuMap.get(char);
-		if (halfWidth !== undefined) {
-			result[i] = halfWidth;
-			continue;
-		}
+    // 全角英数字・記号の変換
+    const halfWidth = zenkakuToHankakuMap.get(char);
+    if (halfWidth !== undefined) {
+      result[i] = halfWidth;
+      continue;
+    }
 
-		// カタカナの変換
-		const hiragana = katakanaToHiraganaMap.get(char);
-		if (hiragana !== undefined) {
-			result[i] = hiragana;
-			continue;
-		}
+    // カタカナの変換
+    const hiragana = katakanaToHiraganaMap.get(char);
+    if (hiragana !== undefined) {
+      result[i] = hiragana;
+      continue;
+    }
 
-		// その他の文字はそのまま追加
-		result[i] = char;
-	}
+    // その他の文字はそのまま追加
+    result[i] = char;
+  }
 
-	return result.join('').toLowerCase();
+  return result.join('').toLowerCase();
 }

--- a/app/query-normalizer.ts
+++ b/app/query-normalizer.ts
@@ -23,14 +23,13 @@ const initKatakanaToHiraganaMap = (): void => {
   }
 };
 
-// マップの初期化を一度だけ実行
 initZenkakuToHankakuMap();
 initKatakanaToHiraganaMap();
 
 /**
- * 文字列を配列に分割せずに直接変換を行う最適化された関数
- * @param text 変換対象テキスト
- * @returns 変換後のテキスト
+ * キーワードフィルタリング用のクエリを正規化します。
+ * @param text 正規化対象テキスト
+ * @returns 正規化後のテキスト
  */
 export function normalizeQuery(text: string): string {
   text = text.trim();

--- a/app/query-normalizer.ts
+++ b/app/query-normalizer.ts
@@ -1,0 +1,63 @@
+
+// 全角英数字・記号の変換マップ
+const zenkakuToHankakuMap: Map<string, string> = new Map();
+const initZenkakuToHankakuMap = (): void => {
+	for (let i = 0; i < 95; i++) {
+		const zenkaku = String.fromCharCode(0xFF01 + i);
+		const hankaku = String.fromCharCode(0x21 + i);
+		if (zenkaku === '（' || zenkaku === '）') {
+			// カッコは演算順序制御と競合するため変換しない
+			continue;
+		}
+		zenkakuToHankakuMap.set(zenkaku, hankaku);
+	}
+};
+
+// カタカナ→ひらがなの変換マップ
+const katakanaToHiraganaMap: Map<string, string> = new Map();
+const initKatakanaToHiraganaMap = (): void => {
+	for (let i = 0; i < 86; i++) {
+		const katakana = String.fromCharCode(0x30A1 + i);
+		const hiragana = String.fromCharCode(0x3041 + i);
+		katakanaToHiraganaMap.set(katakana, hiragana);
+	}
+};
+
+// マップの初期化を一度だけ実行
+initZenkakuToHankakuMap();
+initKatakanaToHiraganaMap();
+
+/**
+ * 文字列を配列に分割せずに直接変換を行う最適化された関数
+ * @param text 変換対象テキスト
+ * @returns 変換後のテキスト
+ */
+export function normalizeQuery(text: string): string {
+	text = text.trim();
+
+	const len = text.length;
+	const result = new Array<string>(len);
+
+	for (let i = 0; i < len; i++) {
+		const char = text[i];
+
+		// 全角英数字・記号の変換
+		const halfWidth = zenkakuToHankakuMap.get(char);
+		if (halfWidth !== undefined) {
+			result[i] = halfWidth;
+			continue;
+		}
+
+		// カタカナの変換
+		const hiragana = katakanaToHiraganaMap.get(char);
+		if (hiragana !== undefined) {
+			result[i] = hiragana;
+			continue;
+		}
+
+		// その他の文字はそのまま追加
+		result[i] = char;
+	}
+
+	return result.join('').toLowerCase();
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "vite build --mode client && vite build",
     "preview": "wrangler pages dev",
     "deploy": "$npm_execpath run build && wrangler pages deploy",
-    "test": "vite-node ./app/__tests__/query-parser.test.ts && vite-node ./app/__tests__/get-japanese-date.test.ts"
+    "test": "vite-node ./app/__tests__/query-parser.test.ts && vite-node ./app/__tests__/query-normalizer.test.ts && vite-node ./app/__tests__/get-japanese-date.test.ts"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## 関連issue
Close #13 

## 現状の課題
キーワード検索において、アルファベットの大文字/小文字、全角/半角、カタカナ/ひらがなの違いが無視されておらず、
- 「[「Google Play ベストオブ 2019」にノミネート！](https://kemono-friends-3.jp/info/detail/001154c6eAwoQ3.html)」が「google」でヒットしない
- 「[(8/18 18:50修正)メインストーリー＜シーズン２＞７章公開！](https://kemono-friends-3.jp/info/detail/007934DJNJYk2d.html)」が「<シーズン2>」でヒットしない
- 「[すぺしゃるクエストに「期間限定クエスト」登場！](https://kemono-friends-3.jp/info/detail/011870g5xbULYM.html)」が「スペシャルクエスト」でヒットしない

などの問題があります。

## 実装詳細
以下の変換を行う`app\query-normalizer.ts`を追加し、フィルタ実行前に、検索キーワードと検索対象タイトルに適用します。
- アルファベットを小文字に置換
- 全角のアルファベット、数字、記号類を半角に置換
- カタカナをひらがなに変換

ただし、`(` `)`の全角半角は、演算順序制御のための`(` `)`と競合するため少し厄介なので、一旦全角（）の変換は行わないこととしました。

## テスト
`query-normalizer`のための簡易のユニットテストコードを`app\__tests__\query-normalizer.test.ts`に追加しました。
全テストが正常に通過することを確認済みです。

## 確認項目
- 追加したテストコードをパスすること
- 以下のようなキーワード検索が正常に動作することを確認
  - 「[「Google Play ベストオブ 2019」にノミネート！](https://kemono-friends-3.jp/info/detail/001154c6eAwoQ3.html)」が「google」や「ｇｏＯｇＬｅ」でヒットする
  - 「[(8/18 18:50修正)メインストーリー＜シーズン２＞７章公開！](https://kemono-friends-3.jp/info/detail/007934DJNJYk2d.html)」が「<シーズン2>」「<しーずん２＞」でヒットする
  - 「[すぺしゃるクエストに「期間限定クエスト」登場！](https://kemono-friends-3.jp/info/detail/011870g5xbULYM.html)」が「スペシャルクエスト」でヒットする