### PR TITLE
a-のようなクエリで検索すると無限ループになる不具合の修正とvitestの導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,11 @@ bun run dev
 ### 7. テストケース実行
 
 ```bash
-npm run test
+npm test
+```
+
+or
+
+```bash
+bun run test
 ```

--- a/app/__tests__/get-japanese-date.test.ts
+++ b/app/__tests__/get-japanese-date.test.ts
@@ -1,52 +1,41 @@
+import { describe, it, expect } from 'vitest';
 import { getJapaneseDate } from "../get-japanese-date";
 import dayjs from "dayjs";
 import "dayjs/locale/ja";
 
-function test(testName: string, fn: () => boolean) {
-  try {
-    const result = fn();
-    console.log(`${result ? "✅" : "❌"} ${testName}`);
-  } catch (error) {
-    console.log(`❌ ${testName}`);
-    console.error(" ", error);
-  }
-}
-
-export function runTests() {
+describe('getJapaneseDate', () => {
   const UtcDateMock = "2021-12-31T15:00:00Z"; // 日本時間とUTCとの差が9時間のため、日本時間で2022-01-01になる
-  test("日本時間が正しく表示されるか", () => {
+
+  it('日本時間が正しく表示されるか', () => {
     dayjs.locale("ja");
     const expected = dayjs(UtcDateMock).format("YYYY-MM-DD"); // 2022-01-01
     const actual = getJapaneseDate(UtcDateMock); // 2022-01-01
-    return expected === actual;
+    expect(actual).toBe(expected);
   });
 
-  test("Date関数とgetJapaneseDateの結果が異なるか", () => {
+  it('Date関数とgetJapaneseDateの結果が異なるか', () => {
     const expected = new Date(UtcDateMock).toISOString().split("T")[0]; // 2021-12-31
     const actual = getJapaneseDate(UtcDateMock); // 2022-01-01
-    return expected !== actual;
+    expect(actual).not.toBe(expected);
   });
 
-  test("現在日時が返るか", () => {
+  it('現在日時が返るか', () => {
     const expected = dayjs().format("YYYY-MM-DD");
     const actual = getJapaneseDate();
-    return expected === actual;
+    expect(actual).toBe(expected);
   });
 
-  test("DateオブジェクトとgetJapaneseDateでギリギリ日付が変わるケース", () => {
+  it('DateオブジェクトとgetJapaneseDateでギリギリ日付が変わるケース', () => {
     const UtcDateMock = "2021-12-31T15:00:00Z"; // 日本時間でギリギリ2022-01-01になる
     const expected = new Date(UtcDateMock).toISOString().split("T")[0]; // 2021-12-31
     const actual = getJapaneseDate(UtcDateMock); // 2022-01-01
-    return expected !== actual;
+    expect(actual).not.toBe(expected);
   });
 
-  test("DateオブジェクトとgetJapaneseDateでギリギリ日付が変わらないケース", () => {
+  it('DateオブジェクトとgetJapaneseDateでギリギリ日付が変わらないケース', () => {
     const UtcDateMock = "2021-12-31T14:59:59Z"; // 日本時間でギリギリ2021-12-31になる
     const expected = new Date(UtcDateMock).toISOString().split("T")[0]; // 2021-12-31
     const actual = getJapaneseDate(UtcDateMock); // 2021-12-31
-    return expected === actual;
+    expect(actual).toBe(expected);
   });
-}
-
-console.log("get-japanese-date Tests:");
-runTests();
+});

--- a/app/__tests__/query-normalizer.test.ts
+++ b/app/__tests__/query-normalizer.test.ts
@@ -1,51 +1,38 @@
-// 簡易のテストケース
+// Vitestを使用したテスト
 
+import { describe, it, expect } from 'vitest';
 import { normalizeQuery } from '../query-normalizer';
 
-function test(testName: string, fn: () => boolean) {
-  try {
-    const result = fn();
-    console.log(`${result ? '✅' : '❌'} ${testName}`);
-  } catch (error) {
-    console.log(`❌ ${testName}`);
-    console.error(' ', error);
-  }
-}
-
-export function runTests() {
+describe('Query Normalizer', () => {
   // 半角アルファベットの大文字小文字の変換
-  test('半角アルファベットの大文字小文字の変換', () => {
+  it('半角アルファベットの大文字小文字の変換', () => {
     const query = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
     const expected = 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz';
     const actual = normalizeQuery(query);
-    return actual === expected
+    expect(actual).toBe(expected);
   });
 
   // 全角英数字と記号類の変換
-  test('全角英数字と記号類の変換(カッコだけそのまま)', () => {
+  it('全角英数字と記号類の変換(カッコだけそのまま)', () => {
     const query = '！＂＃＄％＆＇（）＊＋，－．／０１２３４５６７８９：；＜＝＞？＠ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ［＼］＾＿｀ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ｛｜｝～';
     const expected = '!"#$%&\'（）*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
     const actual = normalizeQuery(query);
-    return actual === expected;
+    expect(actual).toBe(expected);
   });
 
   // カタカナの変換
-  test('カタカナの変換', () => {
+  it('カタカナの変換', () => {
     const query = 'あアいイうウえエおオ　らラりリるルれレろロ　ぁァがパぃィぅゥづプぇェぉォじピゃャじュょョっッ';
     const expected = 'ああいいううええおお　ららりりるるれれろろ　ぁぁがぱぃぃぅぅづぷぇぇぉぉじぴゃゃじゅょょっっ';
     const actual = normalizeQuery(query);
-    return actual === expected;
+    expect(actual).toBe(expected);
   });
 
   // 余分なスペースの削除
-  test('余分なスペースの削除', () => {
+  it('余分なスペースの削除', () => {
     const query = '　 　 あイう　　  ';
     const expected = 'あいう';
     const actual = normalizeQuery(query);
-    return actual === expected;
+    expect(actual).toBe(expected);
   });
-}
-
-// テストの実行
-console.log('Query Normalizer Tests:');
-runTests();
+});

--- a/app/__tests__/query-normalizer.test.ts
+++ b/app/__tests__/query-normalizer.test.ts
@@ -1,5 +1,3 @@
-// Vitestを使用したテスト
-
 import { describe, it, expect } from 'vitest';
 import { normalizeQuery } from '../query-normalizer';
 

--- a/app/__tests__/query-parser.test.ts
+++ b/app/__tests__/query-parser.test.ts
@@ -202,6 +202,13 @@ describe('QueryParser', () => {
           expect(evaluator('測定掃除')).toBe(false);
           expect(evaluator('測定AND掃除')).toBe(true);
         });
+
+        it('AND単体', () => {
+          const parser = new QueryParser('AND');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定AND掃除')).toBe(true);
+        });
       });
 
       describe('不正なOR', () => {
@@ -244,6 +251,13 @@ describe('QueryParser', () => {
           expect(evaluator('測定掃除')).toBe(false);
           expect(evaluator('測定OR掃除')).toBe(true);
         });
+
+        it('OR単体', () => {
+          const parser = new QueryParser('OR');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定OR掃除')).toBe(true);
+        });
       });
 
       describe('不正なNOT', () => {
@@ -261,6 +275,13 @@ describe('QueryParser', () => {
           expect(evaluator('テスト')).toBe(false);
           expect(evaluator('測定a掃b除')).toBe(false);
           expect(evaluator('測定a-b掃除')).toBe(true);
+        });
+
+        it('NOT単体', () => {
+          const parser = new QueryParser('-');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定-掃除')).toBe(true);
         });
       });
     });

--- a/app/__tests__/query-parser.test.ts
+++ b/app/__tests__/query-parser.test.ts
@@ -1,269 +1,318 @@
-// 簡易のテストケース
-
+import { describe, it, expect } from 'vitest';
 import { QueryParser } from '../query-parser';
 
-function test(testName: string, fn: () => boolean) {
-    try {
-        const result = fn();
-        console.log(`${result ? '✅' : '❌'} ${testName}`);
-    } catch (error) {
-        console.log(`❌ ${testName}`);
-        console.error(' ', error);
-    }
-}
+describe('QueryParser', () => {
+  it('単一単語の単純なクエリ', () => {
+    const parser = new QueryParser('測定');
+    const evaluator = parser.parse();
+    expect(evaluator('測定あり')).toBe(true);
+    expect(evaluator('何もなし')).toBe(false);
+  });
 
-export function runTests() {
-    // 単一単語のテスト
-    test('単一単語', () => {
-        const parser = new QueryParser('測定');
-        return (
-            parser.parse()('測定あり') === true &&
-            parser.parse()('何もなし') === false
-        );
+  describe('基本演算子', () => {
+    it('明示的なAND', () => {
+      const parser = new QueryParser('測定 AND 掃除');
+      const evaluator = parser.parse();
+      expect(evaluator('測定と掃除')).toBe(true);
+      expect(evaluator('測定のみ')).toBe(false);
+      expect(evaluator('掃除のみ')).toBe(false);
+      expect(evaluator('何もなし')).toBe(false);
     });
 
-    // 暗黙的なAND
-    test('暗黙的なAND', () => {
-        const parser = new QueryParser('測定 掃除');
-        return (
-            parser.parse()('測定と掃除') === true &&
-            parser.parse()('測定のみ') === false &&
-            parser.parse()('掃除のみ') === false &&
-			parser.parse()('何もなし') === false
-        );
+    it('暗黙的なAND', () => {
+      const parser = new QueryParser('測定 掃除');
+      const evaluator = parser.parse();
+      expect(evaluator('測定と掃除')).toBe(true);
+      expect(evaluator('測定のみ')).toBe(false);
+      expect(evaluator('掃除のみ')).toBe(false);
+      expect(evaluator('何もなし')).toBe(false);
     });
 
-    // 明示的なAND
-    test('明示的なAND', () => {
-        const parser = new QueryParser('測定 AND 掃除');
-        return (
-            parser.parse()('測定と掃除') === true &&
-            parser.parse()('測定のみ') === false &&
-            parser.parse()('掃除のみ') === false &&
-			parser.parse()('何もなし') === false
-        );
+    it('OR', () => {
+      const parser = new QueryParser('測定 OR 掃除');
+      const evaluator = parser.parse();
+      expect(evaluator('測定と掃除')).toBe(true);
+      expect(evaluator('測定のみ')).toBe(true);
+      expect(evaluator('掃除のみ')).toBe(true);
+      expect(evaluator('何もなし')).toBe(false);
     });
 
-    // OR
-    test('OR', () => {
-        const parser = new QueryParser('測定 OR 掃除');
-        return (
-            parser.parse()('測定と掃除') === true &&
-            parser.parse()('測定のみ') === true &&
-            parser.parse()('掃除のみ') === true &&
-            parser.parse()('何もなし') === false
-        );
+    it('単純なNOT', () => {
+      const parser = new QueryParser('-測定');
+      const evaluator = parser.parse();
+      expect(evaluator('なし')).toBe(true);
+      expect(evaluator('測定あり')).toBe(false);
+    });
+  });
+
+  describe('小文字のandとor', () => {
+    it('明示的なAND', () => {
+      const parser = new QueryParser('測定 and 掃除');
+      const evaluator = parser.parse();
+      expect(evaluator('測定と掃除')).toBe(true);
+      expect(evaluator('測定のみ')).toBe(false);
+      expect(evaluator('掃除のみ')).toBe(false);
+      expect(evaluator('何もなし')).toBe(false);
     });
 
-    // 単純なNOT
-    test('単純なNOT', () => {
-        const parser = new QueryParser('-測定');
-        return (
-            parser.parse()('なし') === true &&
-			parser.parse()('測定あり') === false
-        );
+    it('OR', () => {
+      const parser = new QueryParser('測定 or 掃除');
+      const evaluator = parser.parse();
+      expect(evaluator('測定と掃除')).toBe(true);
+      expect(evaluator('測定のみ')).toBe(true);
+      expect(evaluator('掃除のみ')).toBe(true);
+      expect(evaluator('何もなし')).toBe(false);
+    });
+  });
+
+  describe('複合演算子', () => {
+    it('ANDとNOTの組み合わせ', () => {
+      const parser = new QueryParser('掃除 -測定');
+      const evaluator = parser.parse();
+      expect(evaluator('掃除のみ')).toBe(true);
+      expect(evaluator('測定のみ')).toBe(false);
+      expect(evaluator('掃除と測定')).toBe(false);
+      expect(evaluator('何もなし')).toBe(false);
     });
 
-    // ANDとNOTの組み合わせ
-    test('ANDとNOTの組み合わせ', () => {
-        const parser = new QueryParser('掃除 -測定');
-        return (
-            parser.parse()('掃除のみ') === true &&
-            parser.parse()('測定のみ') === false &&
-            parser.parse()('掃除と測定') === false &&
-			parser.parse()('何もなし') === false
-        );
+    it('ORとNOTの組み合わせ', () => {
+      const parser = new QueryParser('掃除 OR -測定');
+      const evaluator = parser.parse();
+      expect(evaluator('掃除あり')).toBe(true);
+      expect(evaluator('測定あり')).toBe(false);
+      expect(evaluator('何もなし')).toBe(true);
+      expect(evaluator('掃除あり測定あり')).toBe(true);
+    });
+  });
+
+  describe('グルーピング', () => {
+    it('単純な括弧', () => {
+      const parser = new QueryParser('(測定 掃除)');
+      const evaluator = parser.parse();
+      expect(evaluator('測定と掃除')).toBe(true);
+      expect(evaluator('測定のみ')).toBe(false);
+      expect(evaluator('掃除のみ')).toBe(false);
+      expect(evaluator('何もなし')).toBe(false);
     });
 
-    // ORとNOTの組み合わせ
-    test('ORとNOTの組み合わせ', () => {
-        const parser = new QueryParser('掃除 OR -測定');
-        return (
-            parser.parse()('掃除あり') === true &&
-            parser.parse()('測定あり') === false &&
-            parser.parse()('何もなし') === true &&
-            parser.parse()('掃除あり測定あり') === true
-        );
+    it('冗長な括弧', () => {
+      const parser = new QueryParser('((((測定)) (掃除)))');
+      const evaluator = parser.parse();
+      expect(evaluator('測定と掃除')).toBe(true);
+      expect(evaluator('測定のみ')).toBe(false);
+      expect(evaluator('掃除のみ')).toBe(false);
+      expect(evaluator('何もなし')).toBe(false);
     });
 
-    // 単純な括弧
-    test('単純な括弧', () => {
-        const parser = new QueryParser('(測定 掃除)');
-        return (
-            parser.parse()('測定と掃除') === true &&
-            parser.parse()('測定のみ') === false &&
-			parser.parse()('掃除のみ') === false &&
-			parser.parse()('何もなし') === false
-        );
+    it('括弧とORの組み合わせ', () => {
+      const parser = new QueryParser('予告 (測定 OR 掃除)');
+      const evaluator = parser.parse();
+      expect(evaluator('測定と掃除の予告')).toBe(true);
+      expect(evaluator('測定の予告')).toBe(true);
+      expect(evaluator('掃除の予告')).toBe(true);
+      expect(evaluator('掃除のみ')).toBe(false);
+      expect(evaluator('測定のみ')).toBe(false);
+      expect(evaluator('何もなし')).toBe(false);
     });
 
-    // 冗長な括弧
-    test('冗長な括弧', () => {
-        const parser = new QueryParser('((((測定)) (掃除)))');
-        return (
-            parser.parse()('測定と掃除') === true &&
-            parser.parse()('測定のみ') === false &&
-			parser.parse()('掃除のみ') === false &&
-			parser.parse()('何もなし') === false
-        );
+    it('括弧とNOTの組み合わせ', () => {
+      const parser = new QueryParser('(測定 -予告)');
+      const evaluator = parser.parse();
+      expect(evaluator('測定あり')).toBe(true);
+      expect(evaluator('予告付きの測定')).toBe(false);
+      expect(evaluator('予告のみ')).toBe(false);
+      expect(evaluator('何もなし')).toBe(false);
+    });
+  });
+
+  describe('複雑なクエリ', () => {
+    it('複雑な組み合わせ1', () => {
+      const parser = new QueryParser('測定 (掃除 OR -メンテナンス)');
+      const evaluator = parser.parse();
+      expect(evaluator('測定と掃除を実施')).toBe(true);
+      expect(evaluator('測定のみを実施')).toBe(true);
+      expect(evaluator('測定とメンテナンス')).toBe(false);
     });
 
-    // 括弧とORの組み合わせ
-    test('括弧とORの組み合わせ', () => {
-        const parser = new QueryParser('予告 (測定 OR 掃除)');
-        return (
-            parser.parse()('測定と掃除の予告') === true &&
-            parser.parse()('測定の予告') === true &&
-            parser.parse()('掃除の予告') === true &&
-            parser.parse()('掃除のみ') === false &&
-            parser.parse()('測定のみ') === false &&
-			parser.parse()('何もなし') === false
-        );
+    it('複雑な組み合わせ2', () => {
+      const parser = new QueryParser('(測定 OR メンテナンス) -予告 掃除');
+      const evaluator = parser.parse();
+      expect(evaluator('測定と掃除')).toBe(true);
+      expect(evaluator('メンテナンスと掃除を実施')).toBe(true);
+      expect(evaluator('予告付きの測定と掃除')).toBe(false);
+      expect(evaluator('何もなし')).toBe(false);
+    });
+  });
+
+  describe('不正なクエリ', () => {
+    it('不正な括弧（開き括弧なし）', () => {
+      const parser = new QueryParser('測定) 掃除');
+      const evaluator = parser.parse();
+      expect(evaluator('テスト')).toBe(false);
+      expect(evaluator('定)')).toBe(false);
+      expect(evaluator('測定)と掃除')).toBe(true);
     });
 
-    // 括弧とNOTの組み合わせ
-    test('括弧とNOTの組み合わせ', () => {
-        const parser = new QueryParser('(測定 -予告)');
-        return (
-            parser.parse()('測定あり') === true &&
-            parser.parse()('予告付きの測定') === false &&
-            parser.parse()('予告のみ') === false &&
-			parser.parse()('何もなし') === false
-        );
+    it('不正な括弧（閉じ括弧なし）', () => {
+      const parser = new QueryParser('測定 (掃除');
+      const evaluator = parser.parse();
+      expect(evaluator('テスト')).toBe(false);
+      expect(evaluator('(掃')).toBe(false);
+      expect(evaluator('(掃除測定')).toBe(true);
     });
 
-    // 複雑な組み合わせ1
-    test('複雑な組み合わせ1', () => {
-        const parser = new QueryParser('測定 (掃除 OR -メンテナンス)');
-        return (
-            parser.parse()('測定と掃除を実施') === true &&
-            parser.parse()('測定のみを実施') === true &&
-            parser.parse()('測定とメンテナンス') === false
-        );
+    describe('不正な演算子', () => {
+      describe('不正なAND', () => {
+        it('右オペランドなし', () => {
+          const parser = new QueryParser('測定 掃除 AND');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定掃除')).toBe(false);
+          expect(evaluator('測定掃除AND')).toBe(true);
+        });
+
+        it('左オペランドなし', () => {
+          const parser = new QueryParser('AND 測定 掃除');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定掃除')).toBe(false);
+          expect(evaluator('測定掃除AND')).toBe(true);
+        });
+
+        it('右スペースなし', () => {
+          const parser = new QueryParser('測定 AND掃除');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定掃除')).toBe(false);
+          expect(evaluator('測定AND掃除')).toBe(true);
+        });
+
+        it('左スペースなし', () => {
+          const parser = new QueryParser('測定AND 掃除');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定掃除')).toBe(false);
+          expect(evaluator('測定AND掃除')).toBe(true);
+        });
+
+        it('左右スペースなし', () => {
+          const parser = new QueryParser('測定AND掃除');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定掃除')).toBe(false);
+          expect(evaluator('測定AND掃除')).toBe(true);
+        });
+      });
+
+      describe('不正なOR', () => {
+        it('右オペランドなし', () => {
+          const parser = new QueryParser('測定 掃除 OR');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定掃除')).toBe(false);
+          expect(evaluator('測定掃除OR')).toBe(true);
+        });
+
+        it('左オペランドなし', () => {
+          const parser = new QueryParser('OR 測定 掃除');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定掃除')).toBe(false);
+          expect(evaluator('測定掃除OR')).toBe(true);
+        });
+
+        it('右スペースなし', () => {
+          const parser = new QueryParser('測定 OR掃除');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定掃除')).toBe(false);
+          expect(evaluator('測定OR掃除')).toBe(true);
+        });
+
+        it('左スペースなし', () => {
+          const parser = new QueryParser('測定OR 掃除');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定掃除')).toBe(false);
+          expect(evaluator('測定OR掃除')).toBe(true);
+        });
+
+        it('左右スペースなし', () => {
+          const parser = new QueryParser('測定OR掃除');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定掃除')).toBe(false);
+          expect(evaluator('測定OR掃除')).toBe(true);
+        });
+      });
+
+      describe('不正なNOT', () => {
+        it('オペランドなし', () => {
+          const parser = new QueryParser('a -');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定a掃除')).toBe(false);
+          expect(evaluator('測定a掃除-')).toBe(true);
+        });
+
+        it('左スペースなし', () => {
+          const parser = new QueryParser('a-b');
+          const evaluator = parser.parse();
+          expect(evaluator('テスト')).toBe(false);
+          expect(evaluator('測定a掃b除')).toBe(false);
+          expect(evaluator('測定a-b掃除')).toBe(true);
+        });
+      });
     });
 
-    // 複雑な組み合わせ2
-    test('複雑な組み合わせ2', () => {
-        const parser = new QueryParser('(測定 OR メンテナンス) -予告 掃除');
-        return (
-            parser.parse()('測定と掃除') === true &&
-            parser.parse()('メンテナンスと掃除を実施') === true &&
-            parser.parse()('予告付きの測定と掃除') === false &&
-			parser.parse()('何もなし') === false
-        );
+    describe('その他のエラー', () => {
+      it('()単体', () => {
+        const parser = new QueryParser('()');
+        const evaluator = parser.parse();
+        expect(evaluator('テスト')).toBe(false);
+        expect(evaluator('測定()掃除')).toBe(true);
+      });
+
+      it('ANDの後にOR', () => {
+        const parser = new QueryParser('aaa and or');
+        const evaluator = parser.parse();
+        expect(evaluator('テスト')).toBe(false);
+        expect(evaluator('aaa掃除')).toBe(false);
+        expect(evaluator('or掃除')).toBe(false);
+        expect(evaluator('aaa測定or掃除')).toBe(true);
+      });
+
+      it('ORの後にAND', () => {
+        const parser = new QueryParser('aaa or and');
+        const evaluator = parser.parse();
+        expect(evaluator('テスト')).toBe(false);
+        expect(evaluator('aaa測定掃除')).toBe(true);
+        expect(evaluator('測定and掃除')).toBe(true);
+      });
+
+      it('ANDの前に-', () => {
+        const parser = new QueryParser('aaa -and');
+        const evaluator = parser.parse();
+        expect(evaluator('テスト')).toBe(false);
+        expect(evaluator('aaa掃除')).toBe(false);
+        expect(evaluator('掃除-and')).toBe(false);
+        expect(evaluator('aaa掃除and')).toBe(false);
+        expect(evaluator('aaa測定-and掃除')).toBe(true);
+      });
+
+      it('ORの前に-', () => {
+        const parser = new QueryParser('aaa -or');
+        const evaluator = parser.parse();
+        expect(evaluator('テスト')).toBe(false);
+        expect(evaluator('aaa掃除')).toBe(false);
+        expect(evaluator('aaa測定-or掃除')).toBe(true);
+      });
+
+      it('閉じ括弧の前に-', () => {
+        const parser = new QueryParser('(aaa -)');
+        const evaluator = parser.parse();
+        expect(evaluator('aaa測定-or掃除')).toBe(true);
+      });
     });
-
-    // エラーケース
-    test('不正な括弧（開き括弧なし）', () => {
-        try {
-            new QueryParser('測定) 掃除').parse()('テスト');
-            return false;
-        } catch {
-            return true;
-        }
-    });
-
-    test('不正な括弧（閉じ括弧なし）', () => {
-        try {
-            new QueryParser('測定 (掃除').parse()('テスト');
-            return false;
-        } catch {
-            return true;
-        }
-    });
-
-    test('不正なAND（右オペランドなし）', () => {
-        try {
-            new QueryParser('測定 掃除 AND').parse()('テスト');
-            return false;
-        } catch {
-            return true;
-        }
-    });
-
-    test('不正なOR（右オペランドなし）', () => {
-        try {
-            new QueryParser('測定 掃除 OR').parse()('テスト');
-            return false;
-        } catch {
-            return true;
-        }
-    });
-
-    test('不正なAND（左オペランドなし）', () => {
-        try {
-            new QueryParser('AND 測定 掃除').parse()('テスト');
-            return false;
-        } catch {
-            return true;
-        }
-    });
-
-    test('不正なOR（右オペランドなし）', () => {
-        try {
-            new QueryParser('OR 測定 掃除').parse()('テスト');
-            return false;
-        } catch {
-            return true;
-        }
-    });
-
-    test('()単体', () => {
-        try {
-            new QueryParser('()').parse()('テスト');
-            return false;
-        } catch {
-            return true;
-        }
-    });
-
-    test('ANDの後にOR', () => {
-        try {
-            new QueryParser('aaa and or').parse()('テスト');
-            return false;
-        } catch {
-            return true;
-        }
-    });
-
-    test('ORの後にAND', () => {
-        try {
-            new QueryParser('aaa or and').parse()('テスト');
-            return false;
-        } catch {
-            return true;
-        }
-    });
-
-    test('ANDの前に-', () => {
-        try {
-            new QueryParser('aaa -and').parse()('テスト');
-            return false;
-        } catch {
-            return true;
-        }
-    });
-
-    test('ORの前に-', () => {
-        try {
-            new QueryParser('aaa -or').parse()('テスト');
-            return false;
-        } catch {
-            return true;
-        }
-    });
-
-    test('閉じ括弧の前に-', () => {
-        try {
-            new QueryParser('(aaa -)').parse()('テスト');
-            return false;
-        } catch {
-            return true;
-        }
-    });
-
-}
-
-// テストの実行
-console.log('Query Parser Tests:');
-runTests();
+  });
+});

--- a/app/query-parser.ts
+++ b/app/query-parser.ts
@@ -1,289 +1,293 @@
-// query-parser.ts
-
 /**
- * クエリで使用可能なトークンの種類を定義
+ * クエリで使用可能なトークンの種類
  */
 export enum TokenType {
-    WORD = 'WORD',
-    AND = 'AND',
-    OR = 'OR',
-    NOT = 'NOT',
-    LEFT_PAREN = 'LEFT_PAREN',
-    RIGHT_PAREN = 'RIGHT_PAREN'
+  WORD = 'WORD',
+  AND = 'AND',
+  OR = 'OR',
+  NOT = 'NOT',
+  LEFT_PAREN = 'LEFT_PAREN',
+  RIGHT_PAREN = 'RIGHT_PAREN'
 }
 
 /**
- * クエリを構成する個々のトークン
+ * クエリを構成するトークン
  */
-export interface Token {
-    type: TokenType;
-    value: string;
-    position: number;
-}
-
-/**
- * パース処理中に発生するエラー
- */
-export class QueryParseError extends Error {
-    constructor(message: string, public position: number) {
-        super(`${message} at position ${position}`);
-        this.name = 'QueryParseError';
-    }
+interface Token {
+  type: TokenType;
+  value: string;
 }
 
 /**
  * クエリを解析して検索条件を生成するパーサー
  */
 export class QueryParser {
-    private tokens: Token[] = [];
-    private currentPosition = 0;
+  private tokens: Token[] = [];
+  private currentPosition = 0;
 
-    /**
-     * クエリ文字列からパーサーを初期化
-     */
-    constructor(private queryString: string) {
-        this.tokenize();
-    }
+  /**
+   * クエリ文字列からパーサーを初期化
+   */
+  constructor(private query: string) {
+    this.tokens = this.tokenize();
+  }
 
-    /**
-     * クエリ文字列を解析して判定関数を返す
-     */
-    public parse(): (text: string) => boolean {
-        this.currentPosition = 0;
-        return this.parseExpression();
-    }
+  /**
+   * クエリ文字列を解析して判定関数を返す
+   */
+  public parse(): (text: string) => boolean {
+    this.currentPosition = 0;
+    return this.parseExpression();
+  }
 
-    /**
-     * クエリ文字列をトークンに分割
-     */
-    private tokenize(): void {
-        const tokens: Token[] = [];
-        let position = 0;
-        let i = 0;
-        let parenStack: number[] = [];
+  /**
+   * クエリ文字列をトークンに分割
+   */
+  private tokenize(): Token[] {
+    const tokens: Token[] = [];
+    let i = 0;
 
-        while (i < this.queryString.length) {
-            const char = this.queryString[i];
+    // クエリ文字列を先頭から走査
+    while (i < this.query.length) {
+      const char = this.query[i];
 
-            // 空白をスキップ
-            if (char === ' ' || char === '　') {
-                i++;
-                position++;
-                continue;
-            }
+      // 空白をスキップ
+      if (char === ' ' || char === '　') {
+        i++;
+        continue;
+      }
 
-            // 括弧の処理
-            if (char === '(' || char === ')') {
-                if (char === '(') {
-                    parenStack.push(position);
-                    tokens.push({
-                        type: TokenType.LEFT_PAREN,
-                        value: char,
-                        position
-                    });
-                } else { // char === ')'
-                    if (parenStack.length === 0) {
-                        // 開きカッコがない閉じカッコを検出
-                        throw new QueryParseError('Unmatched closing parenthesis', position);
-                    }
-                    parenStack.pop();
-                    tokens.push({
-                        type: TokenType.RIGHT_PAREN,
-                        value: char,
-                        position
-                    });
-                }
-                i++;
-                position++;
-                continue;
-            }
+      // 括弧の処理
+      if (char === '(') {
+        tokens.push({ type: TokenType.LEFT_PAREN, value: '(' });
+        i++;
+        continue;
+      }
 
-            // NOT演算子(-) の処理
-            if (char === '-' && (i === 0 || this.queryString[i - 1] === ' ' || this.queryString[i - 1] === '　' || this.queryString[i - 1] === '(')) {
-                tokens.push({
-                    type: TokenType.NOT,
-                    value: 'NOT',
-                    position
-                });
-                i++;
-                position++;
-                continue;
-            }
+      if (char === ')') {
+        tokens.push({ type: TokenType.RIGHT_PAREN, value: ')' });
+        i++;
+        continue;
+      }
 
-            // 単語の処理
-            let word = '';
-            const startPos = position;
-            while (i < this.queryString.length &&
-					this.queryString[i] !== ' ' &&
-					this.queryString[i] !== '　' &&
-					this.queryString[i] !== '(' &&
-					this.queryString[i] !== ')' &&
-					this.queryString[i] !== '-') {
-                word += this.queryString[i];
-                i++;
-                position++;
-            }
+      // NOT演算子の処理
+      if (char === '-' &&
+        (i === 0 || /[\s(]/.test(this.query[i-1])) &&
+        (i < this.query.length - 1 && !/[\s()]/.test(this.query[i+1]))) {
+        tokens.push({ type: TokenType.NOT, value: '-' });
+        i++;
+        continue;
+      }
 
-            if (word) {
-                const upperWord = word.toUpperCase();
-                if (upperWord === 'AND' || upperWord === 'OR') {
-                    tokens.push({
-                        type: upperWord === 'AND' ? TokenType.AND : TokenType.OR,
-                        value: upperWord,
-                        position: startPos
-                    });
-                } else {
-                    tokens.push({
-                        type: TokenType.WORD,
-                        value: word,
-                        position: startPos
-                    });
-                }
-            }
+      // 単語の処理
+      let word = '';
+      while (i < this.query.length && !/[\s()]/.test(this.query[i])) {
+        word += this.query[i];
+        i++;
+      }
+
+      if (word) {
+        // ANDとORの特別処理
+        const upperWord = word.toUpperCase();
+        if (upperWord === 'AND') {
+          tokens.push({ type: TokenType.AND, value: 'and' });
+        } else if (upperWord === 'OR') {
+          tokens.push({ type: TokenType.OR, value: 'or' });
+        } else {
+          tokens.push({ type: TokenType.WORD, value: word.toLowerCase() });
         }
+      }
+    }
 
-        // 最終的に開きカッコが残っていた場合はエラー
-        if (parenStack.length > 0) {
-            throw new QueryParseError('Unmatched opening parenthesis', parenStack[0]);
+    // 不正な演算子と括弧を修正
+    const fixedTokens = this.validateTokens(tokens);
+
+    // 暗黙的なANDを挿入
+    return this.insertImplicitAnds(fixedTokens);
+  }
+
+  /**
+   * トークンの正当性をチェックして修正
+   */
+  private validateTokens(tokens: Token[]): Token[] {
+    // 括弧のバランスを修正
+    const stack: number[] = [];
+    const result = tokens.map((token, i) => {
+      if (token.type === TokenType.LEFT_PAREN) {
+        stack.push(i);
+        return token;
+      } else if (token.type === TokenType.RIGHT_PAREN) {
+        if (stack.length === 0) {
+          // 対応する開き括弧がない場合は単語として扱う
+          return { type: TokenType.WORD, value: token.value };
+        } else {
+          stack.pop();
+          return token;
         }
+      } else {
+        return token;
+      }
+    });
 
-        this.tokens = this.insertImplicitAnds(tokens);
-    }
+    // 無効な演算子をWORDに変換
+    return result.map((token, i) => {
+      if ((token.type === TokenType.AND || token.type === TokenType.OR) &&
+        (i === 0 || i === tokens.length - 1)) {
+        // クエリの先頭または末尾にある演算子
+        return { ...token, type: TokenType.WORD };
+      }
 
-    /**
-     * 暗黙的なANDトークンを挿入
-     */
-    private insertImplicitAnds(tokens: Token[]): Token[] {
-        const result: Token[] = [];
-
-        for (let i = 0; i < tokens.length; i++) {
-            const current = tokens[i];
-            result.push(current);
-
-            if (i < tokens.length - 1) {
-                const next = tokens[i + 1];
-                const needsAnd =
-                    // 現在のトークンが単語で、次がNOTまたは単語または左括弧の場合
-                    (current.type === TokenType.WORD &&
-                        (next.type === TokenType.NOT ||
-                         next.type === TokenType.WORD ||
-                         next.type === TokenType.LEFT_PAREN)) ||
-                    // 現在のトークンが右括弧で、次がNOTまたは単語または左括弧の場合
-                    (current.type === TokenType.RIGHT_PAREN &&
-                        (next.type === TokenType.NOT ||
-                         next.type === TokenType.WORD ||
-                         next.type === TokenType.LEFT_PAREN));
-
-                if (needsAnd &&
-                    next.type !== TokenType.OR &&
-                    next.type !== TokenType.AND) {
-                    result.push({
-                        type: TokenType.AND,
-                        value: 'AND',
-                        position: current.position + current.value.length
-                    });
-                }
-            }
+      if ((token.type === TokenType.AND || token.type === TokenType.OR) && i > 0) {
+        const prev = result[i - 1];
+        // 左側が別の演算子または開き括弧の場合
+        if (prev.type === TokenType.AND || prev.type === TokenType.OR ||
+          prev.type === TokenType.NOT || prev.type === TokenType.LEFT_PAREN) {
+          return { ...token, type: TokenType.WORD };
         }
+      }
 
-        return result;
+      if (token.type === TokenType.NOT &&
+        (i === tokens.length - 1 ||
+         (i < tokens.length - 1 &&
+          (result[i + 1].type === TokenType.AND ||
+           result[i + 1].type === TokenType.OR ||
+           result[i + 1].type === TokenType.NOT ||
+           result[i + 1].type === TokenType.RIGHT_PAREN)))) {
+        return { ...token, type: TokenType.WORD };
+      }
+
+      return token;
+    });
+  }
+
+  /**
+   * 暗黙的なANDトークンを挿入
+   */
+  private insertImplicitAnds(tokens: Token[]): Token[] {
+    const result: Token[] = [];
+
+    for (let i = 0; i < tokens.length; i++) {
+      const current = tokens[i];
+      result.push(current);
+
+      if (i < tokens.length - 1) {
+        const next = tokens[i + 1];
+
+        // 暗黙的なANDが必要か判定
+        const needsAnd =
+          (current.type === TokenType.WORD || current.type === TokenType.RIGHT_PAREN) &&
+          (next.type === TokenType.WORD || next.type === TokenType.NOT || next.type === TokenType.LEFT_PAREN);
+
+        if (needsAnd) {
+          result.push({ type: TokenType.AND, value: 'and' });
+        }
+      }
     }
 
-    /**
-     * 現在のトークンを取得
-     */
-    private getCurrentToken(): Token | null {
-        return this.currentPosition < this.tokens.length
-            ? this.tokens[this.currentPosition]
-            : null;
+    return result;
+  }
+
+  /**
+   * 現在のトークンを取得
+   */
+  private getCurrentToken(): Token | null {
+    return this.currentPosition < this.tokens.length ? this.tokens[this.currentPosition] : null;
+  }
+
+  /**
+   * クエリ式全体を解析
+   */
+  private parseExpression(): (text: string) => boolean {
+    let evaluator = this.parseAndExpression();
+
+    while (this.getCurrentToken()?.type === TokenType.OR) {
+      this.currentPosition++; // OR演算子をスキップ
+
+      if (this.currentPosition >= this.tokens.length) {
+        return () => false;
+      }
+
+      const rightEval = this.parseAndExpression();
+      const leftEval = evaluator;
+
+      evaluator = (text: string) => leftEval(text) || rightEval(text);
     }
 
-    /**
-     * トークンを1つ進める
-     */
-    private advance(): void {
+    return (text: string) => evaluator(text.toLowerCase());
+  }
+
+  /**
+   * AND式を解析
+   */
+  private parseAndExpression(): (text: string) => boolean {
+    let evaluator = this.parseTerm();
+
+    while (this.getCurrentToken()?.type === TokenType.AND) {
+      this.currentPosition++; // AND演算子をスキップ
+
+      if (this.currentPosition >= this.tokens.length) {
+        return () => false;
+      }
+
+      const rightEval = this.parseTerm();
+      const leftEval = evaluator;
+
+      evaluator = (text: string) => leftEval(text) && rightEval(text);
+    }
+
+    return evaluator;
+  }
+
+  /**
+   * 単項式(NOTまたは単語)を解析
+   */
+  private parseTerm(): (text: string) => boolean {
+    const token = this.getCurrentToken();
+
+    if (!token) {
+      return () => false;
+    }
+
+    if (token.type === TokenType.NOT) {
+      this.currentPosition++; // NOTをスキップ
+
+      if (this.currentPosition >= this.tokens.length) {
+        return (text: string) => text.includes('-');
+      }
+
+      const operand = this.parseFactor();
+      return (text: string) => !operand(text);
+    }
+
+    return this.parseFactor();
+  }
+
+  /**
+   * 因子(単語または括弧で囲まれた式)を解析
+   */
+  private parseFactor(): (text: string) => boolean {
+    const token = this.getCurrentToken();
+
+    if (!token) {
+      return () => false;
+    }
+
+    this.currentPosition++; // トークンを消費
+
+    if (token.type === TokenType.WORD) {
+      return (text: string) => text.includes(token.value);
+    } else if (token.type === TokenType.LEFT_PAREN) {
+      const expr = this.parseExpression();
+
+      // 閉じ括弧があれば消費
+      if (this.getCurrentToken()?.type === TokenType.RIGHT_PAREN) {
         this.currentPosition++;
+      }
+
+      return expr;
+    } else {
+      // その他のトークンはテキストとして扱う
+      return (text: string) => text.includes(token.value);
     }
-
-    /**
-     * クエリ式全体を解析
-     */
-    private parseExpression(): (text: string) => boolean {
-        let evaluator = this.parseAndExpression();
-
-        while (this.getCurrentToken()?.type === TokenType.OR) {
-            this.advance();
-            const rightEvaluator = this.parseAndExpression();
-            const leftEvaluator = evaluator;
-            evaluator = (text: string) => leftEvaluator(text) || rightEvaluator(text);
-        }
-
-        return evaluator;
-    }
-
-    /**
-     * AND式を解析
-     */
-    private parseAndExpression(): (text: string) => boolean {
-        let evaluator = this.parseNotExpression();
-
-        while (this.getCurrentToken()?.type === TokenType.AND) {
-            this.advance();
-            const rightEvaluator = this.parseNotExpression();
-            const leftEvaluator = evaluator;
-            evaluator = (text: string) => leftEvaluator(text) && rightEvaluator(text);
-        }
-
-        return evaluator;
-    }
-
-    /**
-     * NOT式を解析
-     */
-    private parseNotExpression(): (text: string) => boolean {
-        if (this.getCurrentToken()?.type === TokenType.NOT) {
-            this.advance();
-            const operandEvaluator = this.parsePrimary();
-            return (text: string) => !operandEvaluator(text);
-        }
-        return this.parsePrimary();
-    }
-
-    /**
-     * 基本式（単語またはカッコで囲まれた式）を解析
-     */
-    private parsePrimary(): (text: string) => boolean {
-        const token = this.getCurrentToken();
-        if (!token) {
-            throw new QueryParseError('Unexpected end of query', this.queryString.length);
-        }
-
-        this.advance();
-
-        switch (token.type) {
-            case TokenType.WORD:
-                return (text: string) => text.includes(token.value);
-
-            case TokenType.LEFT_PAREN: {
-                const evaluator = this.parseExpression();
-                const nextToken = this.getCurrentToken();
-
-                if (nextToken?.type !== TokenType.RIGHT_PAREN) {
-                    throw new QueryParseError(
-                        'Missing closing parenthesis',
-                        token.position
-                    );
-                }
-
-                this.advance();
-                return evaluator;
-            }
-
-            default:
-                throw new QueryParseError(
-                    `Unexpected token: ${token.value}`,
-                    token.position
-                );
-        }
-    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "vite build --mode client && vite build",
     "preview": "wrangler pages dev",
     "deploy": "$npm_execpath run build && wrangler pages deploy",
-    "test": "vite-node ./app/__tests__/query-parser.test.ts && vite-node ./app/__tests__/query-normalizer.test.ts && vite-node ./app/__tests__/get-japanese-date.test.ts"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "private": true,
   "dependencies": {
@@ -25,6 +26,7 @@
     "tailwindcss": "^3.4.13",
     "vite": "^5.4.8",
     "vite-node": "^2.1.4",
+    "vitest": "^3.0.8",
     "wrangler": "^3.80.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    environment: 'node',
+	reporters: ['verbose'],
+  },
+})


### PR DESCRIPTION
## 概要
- Close #20
- QueryParserの一部仕様の変更と最適化、テストケースの拡充
  - 前の仕様では、エラーになるクエリの場合はエラーをthrowして、単純な検索にフォールバックしていた
    例: クエリ`ios or and`は`and`のオペランドがないためエラー。単純な検索にフォールバックし、`ios or and`をそのまま含むテキストにだけマッチする
  - 新仕様: エラーになる演算子はテキストとして認識する
    例: クエリ`ios or and`は`ios`または`and`にマッチする
  - テストケースの拡充
    - 演算子の前後にスペースがないケース
    - 演算子単体のケース
- vitestを導入
  - vitestをインストールし、vitest.config.tsファイルを作成
  - テストコードをvitest向けに書き直し
  - `package.json`のテスト用scriptをvitestを使用するように修正

## 新規依存パッケージ
- vitest (`npm install -D vitest`)

## 確認事項
- [x] `a-`で検索した際、無限ループにならないこと
- [x] `ios or and`で検索すると、iOSとAndroidのお知らせがヒットすること
- [x] すべてのテストが通ること